### PR TITLE
Add util tests and centralize fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+
+
+@pytest.fixture
+def sample_vector():
+    return torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+
+
+@pytest.fixture
+def sample_vector_masked_all_true(sample_vector):
+    mask = torch.ones_like(sample_vector, dtype=torch.bool)
+    return sample_vector, mask
+
+
+@pytest.fixture
+def sample_vector_masked_partial():
+    data = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
+    mask = torch.tensor([True, False, True, False, True])
+    return data, mask
+
+
+@pytest.fixture
+def ohlcv_two_points():
+    return torch.tensor(
+        [[10.0, 12.0, 8.0, 10.0, 100.0], [11.0, 13.0, 9.0, 12.0, 150.0]]
+    )
+
+
+@pytest.fixture
+def ohlcv_two_points_masked(ohlcv_two_points):
+    data = ohlcv_two_points.unsqueeze(0)
+    mask = torch.ones(data.shape[:-1], dtype=torch.bool)
+    return data, mask
+
+
+@pytest.fixture
+def ohlcv_single_date():
+    return torch.tensor(
+        [
+            [
+                [10.0, 12.0, 8.0, 10.0, 100.0],
+                [11.0, 13.0, 9.0, 12.0, 150.0],
+                [12.0, 14.0, 10.0, 13.0, 120.0],
+            ]
+        ]
+    )
+
+
+@pytest.fixture
+def ohlcv_single_date_masked(ohlcv_single_date):
+    mask = torch.ones(ohlcv_single_date.shape[:-1], dtype=torch.bool)
+    return ohlcv_single_date, mask

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import torch
+import pytest
+
+from ifera import file_utils
+from ifera.enums import Source
+
+
+class DummyInstrument:
+    def __init__(self, file_symbol: str, type_: str, interval: str) -> None:
+        self.file_symbol = file_symbol
+        self.type = type_
+        self.interval = interval
+
+
+def test_make_path_creates_directories(tmp_path, monkeypatch):
+    monkeypatch.setattr(file_utils.settings, "DATA_FOLDER", str(tmp_path))
+    path = file_utils.make_path(Source.TENSOR, "test", "1m", "AAPL")
+    expected = Path(tmp_path, Source.TENSOR.value, "test", "1m", "AAPL").with_suffix(
+        ".pt.gz"
+    )
+    assert path == expected
+    assert path.parent.is_dir()
+
+
+def test_make_path_remove_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(file_utils.settings, "DATA_FOLDER", str(tmp_path))
+    existing = Path(tmp_path, Source.RAW.value, "foo", "1h", "bar").with_suffix(".zip")
+    existing.parent.mkdir(parents=True)
+    existing.write_text("data")
+    assert existing.exists()
+
+    path = file_utils.make_path(
+        Source.RAW, "foo", "1h", "bar", remove_file=True
+    )
+    assert path == existing
+    assert not path.exists()
+
+
+def test_make_instrument_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(file_utils.settings, "DATA_FOLDER", str(tmp_path))
+    instr = DummyInstrument("ABC1", "fut", "5m")
+    path = file_utils.make_instrument_path(Source.PROCESSED, instr)
+    expected = (
+        Path(tmp_path, Source.PROCESSED.value, "fut", "5m", "ABC1").with_suffix(".zip")
+    )
+    assert path == expected
+
+
+def test_write_and_read_tensor(tmp_path):
+    file_name = tmp_path / "tensor.pt.gz"
+    tensor = torch.arange(6).reshape(2, 3)
+    file_utils.write_tensor_to_gzip(file_name.as_posix(), tensor)
+    loaded = file_utils.read_tensor_from_gzip(file_name.as_posix())
+    torch.testing.assert_close(loaded, tensor)

--- a/tests/test_masked_series.py
+++ b/tests/test_masked_series.py
@@ -13,68 +13,6 @@ from ifera.masked_series import (
 from ifera.series import artr, ema, rtr, sma  # used for expected values
 
 
-# Fixtures
-@pytest.fixture
-def sample_vector():
-    # A simple 1D tensor for testing SMA and EMA functions.
-    return torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
-
-
-@pytest.fixture
-def sample_vector_masked_all_true(sample_vector):
-    # Create a tensor with a mask where all entries are valid.
-    mask = torch.ones_like(sample_vector, dtype=torch.bool)
-    return sample_vector, mask
-
-
-@pytest.fixture
-def sample_vector_masked_partial():
-    # Create a tensor with a mask where some entries are masked out.
-    # Here, positions 1 and 3 are invalid.
-    data = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
-    mask = torch.tensor([True, False, True, False, True])
-    return data, mask
-
-
-@pytest.fixture
-def ohlcv_two_points():
-    # OHLCV data for testing functions that work on financial data.
-    # Shape: [time, channels] where channels = [open, high, low, close, volume]
-    return torch.tensor(
-        [[10.0, 12.0, 8.0, 10.0, 100.0], [11.0, 13.0, 9.0, 12.0, 150.0]]
-    )
-
-
-@pytest.fixture
-def ohlcv_two_points_masked(ohlcv_two_points):
-    # Wrap the OHLCV tensor as a masked tensor with all entries valid.
-    # Here we add a batch dimension so that the input shape is [1, time, channels]
-    data = ohlcv_two_points.unsqueeze(0)
-    mask = torch.ones(data.shape[:-1], dtype=torch.bool)
-    return data, mask
-
-
-@pytest.fixture
-def ohlcv_single_date():
-    # OHLCV data for a single date with multiple time points.
-    # Shape: [date, time, channels]
-    return torch.tensor(
-        [
-            [
-                [10.0, 12.0, 8.0, 10.0, 100.0],
-                [11.0, 13.0, 9.0, 12.0, 150.0],
-                [12.0, 14.0, 10.0, 13.0, 120.0],
-            ]
-        ]
-    )
-
-
-@pytest.fixture
-def ohlcv_single_date_masked(ohlcv_single_date):
-    mask = torch.ones(ohlcv_single_date.shape[:-1], dtype=torch.bool)
-    return ohlcv_single_date, mask
-
-
 # Tests for helper functions: compress_tensor and decompress_tensor
 def test_compress_decompress():
     # Test that decompressing a compressed tensor recovers the original

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -2,37 +2,6 @@ import pytest
 import torch
 from ifera.series import artr, ema, ema_slow, ffill, rtr, sma
 
-# Fixtures for reusable test data
-
-
-@pytest.fixture
-def sample_vector():
-    # A simple 1D tensor for testing sma and ema functions.
-    return torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
-
-
-@pytest.fixture
-def ohlcv_two_points():
-    # Two time-point OHLCV data (shape: [time, channels]) for testing rtr.
-    # Channels: [open, high, low, close, volume]
-    return torch.tensor(
-        [[10.0, 12.0, 8.0, 10.0, 100.0], [11.0, 13.0, 9.0, 12.0, 150.0]]
-    )
-
-
-@pytest.fixture
-def ohlcv_single_date():
-    # OHLCV data for a single date with 3 time points (shape: [date, time, channels])
-    return torch.tensor(
-        [
-            [
-                [10.0, 12.0, 8.0, 10.0, 100.0],
-                [11.0, 13.0, 9.0, 12.0, 150.0],
-                [12.0, 14.0, 10.0, 13.0, 120.0],
-            ]
-        ]
-    )
-
 
 # Tests for sma
 def test_sma(sample_vector):

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from ifera.enums import Scheme, Source
+from ifera import url_utils, file_utils
+
+
+def test_make_url_file_scheme(tmp_path, monkeypatch):
+    monkeypatch.setattr(file_utils.settings, "DATA_FOLDER", str(tmp_path))
+    url = url_utils.make_url(Scheme.FILE, Source.TENSOR, "fut", "1m", "SYM")
+    expected_path = Path(
+        tmp_path, Source.TENSOR.value, "fut", "1m", "SYM"
+    ).with_suffix(".pt.gz")
+    assert url == f"file:{expected_path}"
+
+
+def test_make_url_other_scheme():
+    url = url_utils.make_url(Scheme.S3, Source.RAW, "data", "1d", "ABC")
+    assert url == "s3:raw/data/1d/ABC.zip"


### PR DESCRIPTION
## Summary
- move shared fixtures into `tests/conftest.py`
- update series tests to rely on new shared fixtures
- new unit tests for `file_utils` and `url_utils`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684a88d501d88326ad81edc5b465539d