### PR TITLE
Format ifera modules with black

### DIFF
--- a/ifera/__init__.py
+++ b/ifera/__init__.py
@@ -17,7 +17,14 @@ from .masked_series import masked_artr, masked_ema, masked_rtr, masked_sma
 from .policies import *
 from .series import artr, ema, ema_slow, ffill, rtr, sma
 from .settings import settings
-from .s3_utils import list_s3_objects, download_s3_file, upload_s3_file, delete_s3_file, check_s3_file_exists, rename_s3_file
+from .s3_utils import (
+    list_s3_objects,
+    download_s3_file,
+    upload_s3_file,
+    delete_s3_file,
+    check_s3_file_exists,
+    rename_s3_file,
+)
 from .decorators import ThreadSafeCache
 from .date_utils import calculate_expiration
 

--- a/ifera/config.py
+++ b/ifera/config.py
@@ -431,7 +431,9 @@ class ConfigManager:
 
         # Check if we already have this derived config in the cache
         cache_interval = new_interval if new_interval else parent_config.interval
-        cache_contract_code = contract_code if contract_code else parent_config.contract_code
+        cache_contract_code = (
+            contract_code if contract_code else parent_config.contract_code
+        )
         cache_key = (parent_config.symbol, cache_interval, cache_contract_code)
         if cache_key in self._base_derived_cache:
             return self._base_derived_cache[cache_key]
@@ -532,7 +534,9 @@ class ConfigManager:
 
         # Check if we already have this derived config in the cache
         cache_interval = new_interval if new_interval else parent_config.interval
-        cache_contract_code = contract_code if contract_code else parent_config.contract_code
+        cache_contract_code = (
+            contract_code if contract_code else parent_config.contract_code
+        )
         cache_key = (
             parent_config.broker_name,
             parent_config.symbol,

--- a/ifera/data_loading.py
+++ b/ifera/data_loading.py
@@ -139,14 +139,14 @@ def load_data_tensor(
 
     # Load the tensor from the local file
     file_path = make_instrument_path(source=source, instrument=instrument)
-    
+
     try:
         tensor = read_tensor_from_gzip(str(file_path), device=device)
     except FileNotFoundError as e:
         raise FileNotFoundError(f"Tensor file not found at {file_path}: {e}") from e
-    
+
     tensor = tensor.to(dtype=dtype)
-    
+
     if strip_date_time:
         tensor = tensor[:, 4:].clone()  # Skip first 4 columns
 

--- a/ifera/date_utils.py
+++ b/ifera/date_utils.py
@@ -246,7 +246,8 @@ def _rule_last_business_day_prior_month(
 def _rule_third_last_business_day_prior_month(
     year: int, month: int, asset_class: Optional[str] = None
 ) -> datetime.date:
-    """Trading terminates on the third-last business day of the month prior to the contract month."""
+    """Trading terminates on the third-last business day of the month prior to
+    the contract month."""
     prev_year, prev_month = prior_month(year, month)
     return third_last_business_day_of_month(
         prev_year, prev_month, country="US", asset_class=asset_class
@@ -280,7 +281,8 @@ def _rule_two_bus_days_prior_third_wed(
 def _rule_three_bus_days_before_25th_prior_month(
     year: int, month: int, asset_class: Optional[str] = None
 ) -> datetime.date:
-    """Trading terminates 3 business days before the 25th of the prior month, or 4 if 25th is not a business day."""
+    """Trading terminates 3 business days before the 25th of the prior month,
+    or 4 if 25th is not a business day."""
     prev_year, prev_month = prior_month(year, month)
     d25 = datetime.date(prev_year, prev_month, 25)
     if is_business_day(d25, country="US", asset_class=asset_class):
@@ -292,7 +294,8 @@ def _rule_three_bus_days_before_25th_prior_month(
 def _rule_four_bus_days_before_25th_prior_month(
     year: int, month: int, asset_class: Optional[str] = None
 ) -> datetime.date:
-    """Trading terminates 4 business days before the 25th of the prior month, or 5 if 25th is not a business day."""
+    """Trading terminates 4 business days before the 25th of the prior month,
+    or 5 if 25th is not a business day."""
     prev_year, prev_month = prior_month(year, month)
     d25 = datetime.date(prev_year, prev_month, 25)
     if is_business_day(d25, country="US", asset_class=asset_class):

--- a/ifera/file_utils.py
+++ b/ifera/file_utils.py
@@ -63,6 +63,4 @@ def read_tensor_from_gzip(
 ) -> torch.Tensor:
     """Load a tensor from a gzip-compressed file."""
     with gzip.open(file_name, "rb") as f:
-        return torch.load(
-            f, map_location=device, weights_only=True # type: ignore
-        )
+        return torch.load(f, map_location=device, weights_only=True)  # type: ignore

--- a/ifera/github_utils.py
+++ b/ifera/github_utils.py
@@ -7,6 +7,7 @@ import datetime as dt
 from .settings import settings
 from .decorators import singleton, ThreadSafeCache
 
+
 @singleton
 class GitHubClientSingleton:
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- run `black` on python sources in the `ifera` folder
- wrap long docstring lines in `date_utils.py` to stay under 100 chars

## Testing
- `pylint ifera`
- `bandit -c .bandit.yml -r .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d2b9637a883269a17b53a99657633