### PR TITLE
Add FileManager class tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,3 +145,15 @@ def file_manager_instance():
     yield fm
     if hasattr(FileManager, "_instance"):
         delattr(FileManager, "_instance")
+
+
+@pytest.fixture
+def file_manager_refresh_instance():
+    from ifera.file_manager import FileManager
+
+    if hasattr(FileManager, "_instance"):
+        delattr(FileManager, "_instance")
+    fm = FileManager(config_file="../tests/test_refresh_rules.yml")
+    yield fm
+    if hasattr(FileManager, "_instance"):
+        delattr(FileManager, "_instance")

--- a/tests/helper_module.py
+++ b/tests/helper_module.py
@@ -6,3 +6,8 @@ def process(symbol: str, extra: str = "") -> None:
 def fetch(symbol: str) -> None:
     # Dummy function used for tests
     pass
+
+
+def combine(symbol: str, codes: list[str]) -> None:
+    # Dummy combine function used for tests
+    pass

--- a/tests/test_refresh_rules.yml
+++ b/tests/test_refresh_rules.yml
@@ -1,0 +1,18 @@
+dependency_rules:
+  - dependent: "file:/tmp/intermediate/{symbol}-{code}.txt"
+    refresh_function: "tests.helper_module.fetch"
+  - dependent: "file:/tmp/output/{symbol}.txt"
+    depends_on:
+      - pattern: "file:/tmp/intermediate/{symbol}-{code}.txt"
+        wildcard_expansion: "s3:raw/{symbol}-{code}.txt"
+refresh_rules:
+  - dependent: "file:/tmp/intermediate/{symbol}-{code}.txt"
+    refresh_function: "tests.helper_module.fetch"
+  - dependent: "file:/tmp/output/{symbol}.txt"
+    depends_on:
+      - pattern: "file:/tmp/intermediate/{symbol}-{code}.txt"
+        wildcard_expansion: "s3:raw/{symbol}-{code}.txt"
+    refresh_function:
+      name: "tests.helper_module.combine"
+      list_args:
+        codes: code


### PR DESCRIPTION
## Summary
- add new fixture for refresh-specific FileManager instance
- add helper combine() for tests
- provide refresh-rule config for FileManager
- extend test_file_manager with tests covering build_subgraph, is_up_to_date, refresh_file and _refresh_stale_file branches

## Testing
- `pylint ifera/file_manager.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea7cbcb4c8326b9cbabdefc037245