### PR TITLE
Add where clause support to FileManager

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,3 +157,15 @@ def file_manager_refresh_instance():
     yield fm
     if hasattr(FileManager, "_instance"):
         delattr(FileManager, "_instance")
+
+
+@pytest.fixture
+def file_manager_where_instance():
+    from ifera.file_manager import FileManager
+
+    if hasattr(FileManager, "_instance"):
+        delattr(FileManager, "_instance")
+    fm = FileManager(config_file="../tests/test_dependencies_where.yml")
+    yield fm
+    if hasattr(FileManager, "_instance"):
+        delattr(FileManager, "_instance")

--- a/tests/test_dependencies_where.yml
+++ b/tests/test_dependencies_where.yml
@@ -1,0 +1,15 @@
+dependency_rules:
+  - dependent: "file:/tmp/{type}/{interval}/{symbol}.txt"
+    where:
+      - type: "foo"
+      - interval: ["1m", "5m"]
+    depends_on:
+      - "file:/tmp/raw/foo/{symbol}.txt"
+    refresh_function: "tests.helper_module.process"
+  - dependent: "file:/tmp/{type}/{interval}/{symbol}.txt"
+    where:
+      - type: "bar"
+    depends_on:
+      - "file:/tmp/raw/bar/{symbol}.txt"
+    refresh_function: "tests.helper_module.process"
+refresh_rules: []

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -331,3 +331,18 @@ def test_build_list_args(monkeypatch, file_manager_refresh_instance):
     spec = {"codes": "code"}
     result = fm._build_list_args(file, RuleType.REFRESH, spec)
     assert result == {"codes": ["AA", "BB"]}
+
+
+def test_where_clause_selects_rule(file_manager_where_instance):
+    fm = file_manager_where_instance
+    deps = fm.get_dependencies("file:/tmp/foo/1m/AAA.txt")
+    assert deps == ["file:/tmp/raw/foo/AAA.txt"]
+    deps = fm.get_dependencies("file:/tmp/bar/3m/AAA.txt")
+    assert deps == ["file:/tmp/raw/bar/AAA.txt"]
+
+
+def test_where_clause_no_match(file_manager_where_instance):
+    fm = file_manager_where_instance
+    fm.build_subgraph("file:/tmp/foo/2m/AAA.txt", RuleType.DEPENDENCY)
+    graph = fm.dependency_graph
+    assert list(graph.successors("file:/tmp/foo/2m/AAA.txt")) == []


### PR DESCRIPTION
## Summary
- allow `where` conditions in dependency rules
- add tests for new `where` feature
- update config fixtures for tests

## Testing
- `pylint ifera/file_manager.py tests/conftest.py tests/test_file_manager.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb709189883268ee4dc28bc962149