### PR TITLE
Add expansion_function support for wildcard expansion

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,8 +111,8 @@ def mock_github(monkeypatch):
     client = MagicMock()
     wrapper = SimpleNamespace(github_client=client)
     monkeypatch.setattr(github_utils, "GitHubClientSingleton", lambda: wrapper)
-    github_utils.check_github_file_exists.cache_clear() # type: ignore
-    github_utils.get_github_last_modified.cache_clear() # type: ignore
+    github_utils.check_github_file_exists.cache_clear()  # type: ignore
+    github_utils.get_github_last_modified.cache_clear()  # type: ignore
     return wrapper
 
 
@@ -166,6 +166,18 @@ def file_manager_where_instance():
     if hasattr(FileManager, "_instance"):
         delattr(FileManager, "_instance")
     fm = FileManager(config_file="../tests/test_dependencies_where.yml")
+    yield fm
+    if hasattr(FileManager, "_instance"):
+        delattr(FileManager, "_instance")
+
+
+@pytest.fixture
+def file_manager_expand_function_instance():
+    from ifera.file_manager import FileManager
+
+    if hasattr(FileManager, "_instance"):
+        delattr(FileManager, "_instance")
+    fm = FileManager(config_file="../tests/test_refresh_rules_func.yml")
     yield fm
     if hasattr(FileManager, "_instance"):
         delattr(FileManager, "_instance")

--- a/tests/helper_module.py
+++ b/tests/helper_module.py
@@ -11,3 +11,9 @@ def fetch(symbol: str) -> None:
 def combine(symbol: str, codes: list[str]) -> None:
     # Dummy combine function used for tests
     pass
+
+
+def expand_codes(symbol: str) -> list[dict[str, str]]:
+    """Return two dummy contract codes for expansion tests."""
+    _ = symbol
+    return [{"code": "AA"}, {"code": "BB"}]

--- a/tests/test_refresh_rules_func.yml
+++ b/tests/test_refresh_rules_func.yml
@@ -1,0 +1,18 @@
+dependency_rules:
+  - dependent: "file:/tmp/intermediate/{symbol}-{code}.txt"
+    refresh_function: "tests.helper_module.fetch"
+  - dependent: "file:/tmp/output/{symbol}.txt"
+    depends_on:
+      - pattern: "file:/tmp/intermediate/{symbol}-{code}.txt"
+        expansion_function: "tests.helper_module.expand_codes"
+refresh_rules:
+  - dependent: "file:/tmp/intermediate/{symbol}-{code}.txt"
+    refresh_function: "tests.helper_module.fetch"
+  - dependent: "file:/tmp/output/{symbol}.txt"
+    depends_on:
+      - pattern: "file:/tmp/intermediate/{symbol}-{code}.txt"
+        expansion_function: "tests.helper_module.expand_codes"
+    refresh_function:
+      name: "tests.helper_module.combine"
+      list_args:
+        codes: code


### PR DESCRIPTION
## Summary
- support expansion_function in dependency rules for programmatic wildcard substitution
- add helper function for tests and new YAML config
- extend FileManager tests for function-based expansion

## Testing
- `bandit -c .bandit.yml -r .`
- `pylint ifera tests/helper_module.py tests/test_file_manager.py tests/conftest.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685469c41df08326b21096ee63cecb62