### PR TITLE
Support function dependencies in FileManager

### DIFF
--- a/ifera/dependencies.yml
+++ b/ifera/dependencies.yml
@@ -112,7 +112,10 @@ refresh_rules:
     depends_on:
       - "file:meta/futures/rollover/{symbol}.yml"
       - pattern: "file:tensor/futures_individual/{interval}/{symbol}-{contract_code}.pt.gz"
-        expansion_function: "ifera.file_refresh.contract_codes_for_backadjust"
+        expansion_function:
+          name: "ifera.file_refresh.contract_codes_for_backadjust"
+          depends_on:
+            - "file:meta/futures/rollover/{symbol}.yml"
     refresh_function:
       name: "ifera.file_refresh.process_futures_backadjusted_tensor"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,3 +181,15 @@ def file_manager_expand_function_instance():
     yield fm
     if hasattr(FileManager, "_instance"):
         delattr(FileManager, "_instance")
+
+
+@pytest.fixture
+def file_manager_func_depends_instance():
+    from ifera.file_manager import FileManager
+
+    if hasattr(FileManager, "_instance"):
+        delattr(FileManager, "_instance")
+    fm = FileManager(config_file="../tests/test_refresh_rules_func_depends.yml")
+    yield fm
+    if hasattr(FileManager, "_instance"):
+        delattr(FileManager, "_instance")

--- a/tests/test_refresh_rules_func_depends.yml
+++ b/tests/test_refresh_rules_func_depends.yml
@@ -1,0 +1,28 @@
+dependency_rules:
+  - dependent: "file:/tmp/meta/{symbol}.txt"
+    refresh_function: "tests.helper_module.fetch"
+  - dependent: "file:/tmp/intermediate/{symbol}-{code}.txt"
+    refresh_function: "tests.helper_module.fetch"
+  - dependent: "file:/tmp/output/{symbol}.txt"
+    depends_on:
+      - pattern: "file:/tmp/intermediate/{symbol}-{code}.txt"
+        expansion_function:
+          name: "tests.helper_module.expand_codes"
+          depends_on:
+            - "file:/tmp/meta/{symbol}.txt"
+refresh_rules:
+  - dependent: "file:/tmp/meta/{symbol}.txt"
+    refresh_function: "tests.helper_module.fetch"
+  - dependent: "file:/tmp/intermediate/{symbol}-{code}.txt"
+    refresh_function: "tests.helper_module.fetch"
+  - dependent: "file:/tmp/output/{symbol}.txt"
+    depends_on:
+      - pattern: "file:/tmp/intermediate/{symbol}-{code}.txt"
+        expansion_function:
+          name: "tests.helper_module.expand_codes"
+          depends_on:
+            - "file:/tmp/meta/{symbol}.txt"
+    refresh_function:
+      name: "tests.helper_module.combine"
+      list_args:
+        codes: code


### PR DESCRIPTION
## Summary
- allow expansion/refresh functions to define extra dependencies
- refresh those dependencies before executing the function
- update `dependencies.yml` to use depends_on for the backadjust helper
- test new dependency behaviour for expansion functions

## Testing
- `pylint ifera tests/test_file_manager.py tests/conftest.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ac5ef9448326937da0d340b6dcb4