### PR TITLE
Add tensor_backadjusted source handling

### DIFF
--- a/ifera/data_loading.py
+++ b/ifera/data_loading.py
@@ -130,12 +130,11 @@ def load_data_tensor(
     dtype: torch.dtype = torch.float32,
     device: Optional[torch.device] = None,
     strip_date_time: bool = True,
+    source: Source = Source.TENSOR,
 ) -> torch.Tensor:
     """Load processed data as a PyTorch tensor using dependency-based file refreshing."""
     if device is None:
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    source = Source.TENSOR
-
     # Load the tensor from the local file
     file_path = make_instrument_path(source=source, instrument=instrument)
 

--- a/ifera/dependencies.yml
+++ b/ifera/dependencies.yml
@@ -49,7 +49,7 @@ dependency_rules:
       - "s3:raw/{type}/{interval}/{symbol}.zip"
 
   # Special tensors
-  - dependent: "s3:tensor/futures_backadjusted/{interval}/{symbol}.pt.gz"
+  - dependent: "s3:tensor_backadjusted/futures/{interval}/{symbol}.pt.gz"
     where:
       interval: ["1m", "30m"]
     depends_on:
@@ -118,7 +118,7 @@ refresh_rules:
     refresh_function: "ifera.file_refresh.process_raw_file"
 
   # Special tensors
-  - dependent: "file:tensor/futures_backadjusted/{interval}/{symbol}.pt.gz"
+  - dependent: "file:tensor_backadjusted/futures/{interval}/{symbol}.pt.gz"
     where:
       interval: ["1m", "30m"]
     depends_on:

--- a/ifera/enums.py
+++ b/ifera/enums.py
@@ -15,6 +15,7 @@ class Source(Enum):
     RAW = "raw"
     PROCESSED = "processed"
     TENSOR = "tensor"
+    TENSOR_BACKADJUSTED = "tensor_backadjusted"
     META = "meta"
 
 
@@ -47,5 +48,6 @@ extension_map = {
     Source.RAW: ".zip",
     Source.PROCESSED: ".zip",
     Source.TENSOR: ".pt.gz",
+    Source.TENSOR_BACKADJUSTED: ".pt.gz",
     Source.META: ".yml",
 }

--- a/ifera/file_refresh.py
+++ b/ifera/file_refresh.py
@@ -438,7 +438,6 @@ def contract_codes_for_backadjust(symbol: str, interval: str) -> list[dict]:
     return result
 
 
-
 def process_futures_backadjusted_tensor(
     symbol: str, interval: str, contract_codes: list[str] | None = None
 ) -> None:
@@ -545,6 +544,6 @@ def process_futures_backadjusted_tensor(
     result = rearrange(combined, "(d t) c -> d t c", t=steps)
 
     tensor_file_path = make_path(
-        Source.TENSOR, "futures_backadjusted", interval, symbol
+        Source.TENSOR_BACKADJUSTED, "futures", interval, symbol
     )
     write_tensor_to_gzip(str(tensor_file_path), result)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -17,6 +17,19 @@ def test_make_path_creates_directories(tmp_path, monkeypatch):
     assert path.parent.is_dir()
 
 
+def test_make_path_tensor_backadjusted(tmp_path, monkeypatch):
+    monkeypatch.setattr(file_utils.settings, "DATA_FOLDER", str(tmp_path))
+    path = file_utils.make_path(Source.TENSOR_BACKADJUSTED, "futures", "1m", "AAPL")
+    expected = Path(
+        tmp_path,
+        Source.TENSOR_BACKADJUSTED.value,
+        "futures",
+        "1m",
+        "AAPL",
+    ).with_suffix(".pt.gz")
+    assert path == expected
+
+
 def test_make_path_remove_file(tmp_path, monkeypatch):
     monkeypatch.setattr(file_utils.settings, "DATA_FOLDER", str(tmp_path))
     existing = Path(tmp_path, Source.RAW.value, "foo", "1h", "bar").with_suffix(".zip")

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -8,6 +8,14 @@ def test_make_url_file_scheme(tmp_path, monkeypatch):
     assert url == "file:tensor/fut/1m/SYM.pt.gz"
 
 
+def test_make_url_tensor_backadjusted(tmp_path, monkeypatch):
+    monkeypatch.setattr(file_utils.settings, "DATA_FOLDER", str(tmp_path))
+    url = url_utils.make_url(
+        Scheme.FILE, Source.TENSOR_BACKADJUSTED, "futures", "1m", "SYM"
+    )
+    assert url == "file:tensor_backadjusted/futures/1m/SYM.pt.gz"
+
+
 def test_make_url_other_scheme():
     url = url_utils.make_url(Scheme.S3, Source.RAW, "data", "1d", "ABC")
     assert url == "s3:raw/data/1d/ABC.zip"


### PR DESCRIPTION
## Summary
- add `TENSOR_BACKADJUSTED` source type
- write back-adjusted tensors under the new source
- update dependency rules for `tensor_backadjusted` paths
- allow `load_data_tensor` to specify a source
- test make_url/make_path for the new source

## Testing
- `pylint ifera tests`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb728a45c832687fc29f4d35e1cbd