### PR TITLE
Allow derived base config intervals

### DIFF
--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,21 @@
+import pytest
+
+from ifera import ConfigManager
+
+
+def test_get_base_instrument_config_allowed_interval(config_manager: ConfigManager):
+    cfg = config_manager.get_base_instrument_config(symbol="CL", interval="30m")
+    assert cfg.interval == "30m"
+    assert cfg.parent_config is None
+
+
+def test_get_base_instrument_config_derived_interval(config_manager: ConfigManager):
+    cfg = config_manager.get_base_instrument_config(symbol="CL", interval="1h")
+    assert cfg.interval == "1h"
+    assert cfg.parent_config is not None
+    assert cfg.parent_config.interval == "30m"
+
+
+def test_get_base_instrument_config_invalid_interval(config_manager: ConfigManager):
+    with pytest.raises(ValueError):
+        config_manager.get_base_instrument_config(symbol="CL", interval="45m")


### PR DESCRIPTION
## Summary
- introduce `_find_parent_interval` helper in `ConfigManager`
- create base configs for unsupported intervals using nearest allowed parent
- add tests for derived interval logic

## Testing
- `pylint ifera/config.py tests/test_config_manager.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ae60c8148326af3403ee96e8069f