### PR TITLE
Extend ConfigManager with contract code support

### DIFF
--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -19,3 +19,36 @@ def test_get_base_instrument_config_derived_interval(config_manager: ConfigManag
 def test_get_base_instrument_config_invalid_interval(config_manager: ConfigManager):
     with pytest.raises(ValueError):
         config_manager.get_base_instrument_config(symbol="CL", interval="45m")
+
+
+def test_get_base_instrument_config_contract_code_allowed(
+    config_manager: ConfigManager,
+):
+    cfg = config_manager.get_base_instrument_config(
+        symbol="CL", interval="30m", contract_code="M24"
+    )
+    assert cfg.contract_code == "M24"
+    assert cfg.parent_config is not None
+    assert cfg.parent_config.contract_code is None
+    assert cfg.parent_config.interval == "30m"
+
+
+def test_get_base_instrument_config_contract_code_and_interval(
+    config_manager: ConfigManager,
+):
+    cfg = config_manager.get_base_instrument_config(
+        symbol="CL", interval="1h", contract_code="M24"
+    )
+    assert cfg.interval == "1h"
+    assert cfg.contract_code == "M24"
+    assert cfg.parent_config is not None
+    assert cfg.parent_config.interval == "30m"
+    assert cfg.parent_config.contract_code is None
+
+
+def test_get_config_with_contract_code(config_manager: ConfigManager):
+    cfg = config_manager.get_config(
+        broker_name="IBKR", symbol="CL", interval="30m", contract_code="M24"
+    )
+    assert cfg.contract_code == "M24"
+    assert cfg.broker_symbol == "CLM24"


### PR DESCRIPTION
## Summary
- extend ConfigManager to accept an optional contract_code when getting base configs
- include contract code in config fetching and caching
- remove unused create_derived_config and related cache
- add tests covering new behaviours

## Testing
- `black ifera tests`
- `pylint ifera tests`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c1e301888326a3be068207addee1