### PR TITLE
Fix failing tests after FileManager context update

### DIFF
--- a/tests/test_dependencies_where.yml
+++ b/tests/test_dependencies_where.yml
@@ -12,6 +12,10 @@ dependency_rules:
     depends_on:
       - "file:/tmp/raw/bar/{symbol}.txt"
     refresh_function: "tests.helper_module.process"
+  - dependent: "file:/tmp/raw/foo/{symbol}.txt"
+    refresh_function: "tests.helper_module.fetch"
+  - dependent: "file:/tmp/raw/bar/{symbol}.txt"
+    refresh_function: "tests.helper_module.fetch"
 refresh_rules:
   - dependent: "file:/tmp/{type}/{interval}/{symbol}.txt"
     where:
@@ -26,3 +30,7 @@ refresh_rules:
     depends_on:
       - "file:/tmp/raw/bar/{symbol}.txt"
     refresh_function: "tests.helper_module.process"
+  - dependent: "file:/tmp/raw/foo/{symbol}.txt"
+    refresh_function: "tests.helper_module.fetch"
+  - dependent: "file:/tmp/raw/bar/{symbol}.txt"
+    refresh_function: "tests.helper_module.fetch"

--- a/tests/test_scaled_artr_policy.py
+++ b/tests/test_scaled_artr_policy.py
@@ -12,6 +12,7 @@ class DummyData:
         self.artr = torch.zeros((1, 1), dtype=torch.float32)
         self.device = torch.device("cpu")
         self.dtype = torch.float32
+        self.backadjust = False
 
     def convert_indices(self, *_args):
         return _args


### PR DESCRIPTION
## Summary
- update test dependencies to include rules for raw files
- add missing `backadjust` attribute to `DummyData`

## Testing
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd0684f2083269702f58b4d45e065