### PR TITLE
Add persistent context manager to FileManager

### DIFF
--- a/ifera/policies.py
+++ b/ifera/policies.py
@@ -407,17 +407,16 @@ class ScaledArtrMaintenancePolicy(PositionMaintenancePolicy):
             for stage in stages
         ]
 
-        fm.init_persistent_context()
-        self.derived_data = [
-            dm.get_instrument_data(
-                config,
-                dtype=instrument_data.dtype,
-                device=instrument_data.device,
-                backadjust=instrument_data.backadjust,
-            )
-            for config in self.derived_configs
-        ]
-        fm.clear_persistent_context()
+        with fm.persistentContext():
+            self.derived_data = [
+                dm.get_instrument_data(
+                    config,
+                    dtype=instrument_data.dtype,
+                    device=instrument_data.device,
+                    backadjust=instrument_data.backadjust,
+                )
+                for config in self.derived_configs
+            ]
 
         self.artr_policies = [
             ArtrStopLossPolicy(data, self.atr_multiple) for data in self.derived_data


### PR DESCRIPTION
## Summary
- allow FileManager to be used as a context manager via `persistentContext`
- clean up temporary files when clearing a persistent context
- update ScaledArtrMaintenancePolicy to use the new context manager
- test nested persistent contexts and cleanup behaviour

## Testing
- `pylint ifera tests/test_file_manager.py ifera/policies.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd84d10288326a82cf4e1dcb3b443