### PR TITLE
Implement explicit ARTR calculation

### DIFF
--- a/tests/test_instrument_data.py
+++ b/tests/test_instrument_data.py
@@ -1,0 +1,27 @@
+import torch
+import pytest
+from ifera.data_models import InstrumentData, DataManager
+from ifera.masked_series import masked_artr
+
+
+def test_calculate_artr(monkeypatch, base_instrument_config, ohlcv_single_date):
+    dummy_data = ohlcv_single_date
+
+    def dummy_load(self):
+        self._data = dummy_data
+
+    monkeypatch.setattr(InstrumentData, "_load_data", dummy_load)
+    data = InstrumentData(
+        base_instrument_config,
+        sentinel=DataManager()._sentinel,
+    )
+
+    assert data.artr.numel() == 0
+
+    result = data.calculate_artr(alpha=0.5, acrossday=False)
+
+    mask = torch.ones(dummy_data.shape[:-1], dtype=torch.bool)
+    expected = masked_artr(dummy_data, mask, alpha=0.5, acrossday=False)
+
+    torch.testing.assert_close(result, expected)
+    torch.testing.assert_close(data.artr, expected)


### PR DESCRIPTION
## Summary
- compute ARTR explicitly via `calculate_artr` instead of property lazy init
- remove unused `_artr_mask` and adjust initialization
- keep hyperparameters read-only
- add regression test for `calculate_artr`

## Testing
- `pylint ifera/data_models.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c957257348326951cec59e7e567aa