### PR TITLE
Fix pytest failures after tensor format change

### DIFF
--- a/tests/test_file_refresh.py
+++ b/tests/test_file_refresh.py
@@ -10,12 +10,16 @@ def test_aggregate_from_parent_tensor(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "DATA_FOLDER", str(tmp_path))
 
     parent_steps = 4
-    data = torch.zeros((1, parent_steps, 5), dtype=torch.float32)
+    data = torch.zeros((1, parent_steps, 9), dtype=torch.float32)
     data[0, :, 0] = torch.arange(parent_steps)
     data[0, :, 1] = torch.arange(parent_steps) + 0.5
     data[0, :, 2] = torch.arange(parent_steps) - 0.5
     data[0, :, 3] = torch.arange(parent_steps) + 1.0
-    data[0, :, 4] = torch.arange(parent_steps) + 1
+    data[0, :, 4] = torch.arange(parent_steps)
+    data[0, :, 5] = torch.arange(parent_steps) + 0.5
+    data[0, :, 6] = torch.arange(parent_steps) - 0.5
+    data[0, :, 7] = torch.arange(parent_steps) + 1.0
+    data[0, :, 8] = torch.arange(parent_steps) + 1
 
     parent_path = make_path(Source.TENSOR, "futures", "30m", "CL")
     write_tensor_to_gzip(str(parent_path), data)
@@ -34,8 +38,8 @@ def test_aggregate_from_parent_tensor(tmp_path, monkeypatch):
     expected = torch.tensor(
         [
             [
-                [0.0, 1.5, -0.5, 2.0, 3.0],
-                [2.0, 3.5, 1.5, 4.0, 7.0],
+                [0.0, 0.5, -0.5, 1.0, 0.0, 1.5, -0.5, 2.0, 3.0],
+                [2.0, 2.5, 1.5, 3.0, 2.0, 3.5, 1.5, 4.0, 7.0],
             ]
         ]
     )

--- a/tests/test_instrument_data.py
+++ b/tests/test_instrument_data.py
@@ -5,7 +5,10 @@ from ifera.masked_series import masked_artr
 
 
 def test_calculate_artr(monkeypatch, base_instrument_config, ohlcv_single_date):
-    dummy_data = ohlcv_single_date
+    dummy_data = torch.cat(
+        [torch.zeros(ohlcv_single_date.shape[:-1] + (4,)), ohlcv_single_date],
+        dim=-1,
+    )
 
     def dummy_load(self):
         self._data = dummy_data
@@ -21,7 +24,7 @@ def test_calculate_artr(monkeypatch, base_instrument_config, ohlcv_single_date):
     result = data.calculate_artr(alpha=0.5, acrossday=False)
 
     mask = torch.ones(dummy_data.shape[:-1], dtype=torch.bool)
-    expected = masked_artr(dummy_data, mask, alpha=0.5, acrossday=False)
+    expected = masked_artr(dummy_data[..., 4:], mask, alpha=0.5, acrossday=False)
 
     torch.testing.assert_close(result, expected)
     torch.testing.assert_close(data.artr, expected)


### PR DESCRIPTION
## Summary
- update aggregate-from-parent test for 9 channel tensors
- adapt InstrumentData ARTR test to use full tensor format

## Testing
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d097a9c108326ad7108daece30f0d