### PR TITLE
Add single market environment and trading done policies

### DIFF
--- a/ifera/__init__.py
+++ b/ifera/__init__.py
@@ -13,6 +13,7 @@ from .data_processing import (
 )
 from .file_manager import FileManager, RuleType
 from .market_simulator import MarketSimulatorIntraday
+from .environments import SingleMarketEnv
 from .masked_series import masked_artr, masked_ema, masked_rtr, masked_sma
 from .policies import *
 from .series import artr, ema, ema_slow, ffill, rtr, sma
@@ -55,6 +56,9 @@ __all__ = [
     "ArtrStopLossPolicy",
     "InitialArtrStopLossPolicy",
     "ScaledArtrMaintenancePolicy",
+    "AlwaysFalseDonePolicy",
+    "SingleTradeDonePolicy",
+    "SingleMarketEnv",
     "FileManager",
     "Scheme",
     "Source",

--- a/ifera/environments.py
+++ b/ifera/environments.py
@@ -1,0 +1,127 @@
+"""Environment module for single instrument trading."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from .config import BaseInstrumentConfig
+from .data_models import DataManager, InstrumentData
+from .market_simulator import MarketSimulatorIntraday
+from .policies import TradingPolicy
+
+
+class SingleMarketEnv:
+    """Environment for simulating a single market using :class:`MarketSimulatorIntraday`."""
+
+    def __init__(
+        self,
+        instrument_config: BaseInstrumentConfig,
+        broker_name: str,
+        *,
+        backadjust: bool = False,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        dm = DataManager()
+        self.instrument_data: InstrumentData = dm.get_instrument_data(
+            instrument_config, dtype=dtype, device=device, backadjust=backadjust
+        )
+        self.market_simulator = MarketSimulatorIntraday(
+            instrument_data=self.instrument_data, broker_name=broker_name
+        )
+        self.device = self.instrument_data.device
+        self.dtype = self.instrument_data.dtype
+
+        # State tensors populated in reset
+        self.date_idx = torch.tensor((), dtype=torch.int32, device=self.device)
+        self.time_idx = torch.tensor((), dtype=torch.int32, device=self.device)
+        self.position = torch.tensor((), dtype=torch.int32, device=self.device)
+        self.prev_stop_loss = torch.tensor((), dtype=self.dtype, device=self.device)
+        self.entry_price = torch.tensor((), dtype=self.dtype, device=self.device)
+        self.total_profit = torch.tensor((), dtype=self.dtype, device=self.device)
+        self.done = torch.tensor((), dtype=torch.bool, device=self.device)
+
+    def reset(
+        self,
+        start_date_idx: torch.Tensor,
+        start_time_idx: torch.Tensor,
+        trading_policy: Optional[TradingPolicy] = None,
+    ) -> None:
+        """Reset the environment state for a new simulation."""
+
+        batch_size = start_date_idx.shape[0]
+        self.date_idx = start_date_idx.to(torch.int32).to(self.device)
+        self.time_idx = start_time_idx.to(torch.int32).to(self.device)
+        self.position = torch.zeros(batch_size, dtype=torch.int32, device=self.device)
+        self.prev_stop_loss = torch.full(
+            (batch_size,), float("nan"), dtype=self.dtype, device=self.device
+        )
+        self.entry_price = torch.full(
+            (batch_size,), float("nan"), dtype=self.dtype, device=self.device
+        )
+        self.total_profit = torch.zeros(
+            batch_size, dtype=self.dtype, device=self.device
+        )
+        self.done = torch.zeros(batch_size, dtype=torch.bool, device=self.device)
+
+        if trading_policy is not None and hasattr(
+            trading_policy.trading_done_policy, "reset"
+        ):
+            trading_policy.trading_done_policy.reset(
+                torch.ones(batch_size, dtype=torch.bool, device=self.device)
+            )
+
+    def step(self, trading_policy: TradingPolicy) -> torch.Tensor:
+        """Run one simulation step using ``trading_policy``."""
+
+        action, stop_loss, done = trading_policy(
+            self.date_idx,
+            self.time_idx,
+            self.position,
+            self.prev_stop_loss,
+            self.entry_price,
+        )
+
+        next_date_idx, next_time_idx = self.instrument_data.get_next_indices(
+            self.date_idx, self.time_idx
+        )
+        next_date_idx = torch.where(done, self.date_idx, next_date_idx)
+        next_time_idx = torch.where(done, self.time_idx, next_time_idx)
+        profit, new_position, execution_price, _ = self.market_simulator.calculate_step(
+            next_date_idx, next_time_idx, self.position, action, stop_loss
+        )
+        profit = torch.where(done, torch.zeros_like(profit), profit)
+        new_position = torch.where(done, self.position, new_position)
+        execution_price = torch.where(done, self.entry_price, execution_price)
+
+        entry_mask = (self.position == 0) & (new_position != 0)
+        self.entry_price = torch.where(entry_mask, execution_price, self.entry_price)
+
+        self.date_idx = next_date_idx
+        self.time_idx = next_time_idx
+        self.position = new_position
+        self.prev_stop_loss = stop_loss
+        self.total_profit += profit
+        self.done |= done
+
+        return profit
+
+    def rollout(
+        self,
+        trading_policy: TradingPolicy,
+        start_date_idx: torch.Tensor,
+        start_time_idx: torch.Tensor,
+        max_steps: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Execute a rollout until ``done`` for all batches or ``max_steps`` reached."""
+
+        self.reset(start_date_idx, start_time_idx, trading_policy)
+        steps = 0
+        while True:
+            self.step(trading_policy)
+            steps += 1
+            if self.done.all() or (max_steps is not None and steps >= max_steps):
+                break
+        return self.total_profit.clone()

--- a/tests/test_single_market_env.py
+++ b/tests/test_single_market_env.py
@@ -1,0 +1,133 @@
+import torch
+import pytest
+
+from ifera.policies import (
+    TradingPolicy,
+    AlwaysOpenPolicy,
+    AlwaysFalseDonePolicy,
+    SingleTradeDonePolicy,
+    PositionMaintenancePolicy,
+)
+from ifera.data_models import DataManager
+from ifera.config import BaseInstrumentConfig
+from ifera.environments import SingleMarketEnv
+
+
+class DummyData:
+    def __init__(self, instrument, steps=1):
+        self.instrument = instrument
+        self.data = torch.zeros((1, steps, 4), dtype=torch.float32)
+        self.artr = torch.zeros((1, steps), dtype=torch.float32)
+        self.device = torch.device("cpu")
+        self.dtype = torch.float32
+        self.backadjust = False
+
+    @property
+    def valid_mask(self):
+        return torch.ones((1, self.data.shape[1]), dtype=torch.bool)
+
+    def get_next_indices(self, date_idx, time_idx):
+        next_time = time_idx + 1
+        next_date = date_idx + (next_time >= self.data.shape[1]).long()
+        next_time = torch.where(
+            next_time >= self.data.shape[1], torch.zeros_like(next_time), next_time
+        )
+        return next_date, next_time
+
+
+class DummyInitialStopLoss(torch.nn.Module):
+    def forward(self, date_idx, time_idx, action):
+        return torch.zeros_like(action, dtype=torch.float32)
+
+
+class DummyMaintenance(PositionMaintenancePolicy):
+    def reset(self, mask: torch.Tensor) -> None:
+        pass
+
+    def forward(
+        self,
+        date_idx: torch.Tensor,
+        time_idx: torch.Tensor,
+        position: torch.Tensor,
+        prev_stop: torch.Tensor,
+        entry_price: torch.Tensor,
+        batch_indices: torch.Tensor,
+    ):
+        return torch.zeros_like(position), prev_stop
+
+
+class CloseAfterOneStep(PositionMaintenancePolicy):
+    def reset(self, mask: torch.Tensor) -> None:
+        pass
+
+    def forward(
+        self,
+        date_idx: torch.Tensor,
+        time_idx: torch.Tensor,
+        position: torch.Tensor,
+        prev_stop: torch.Tensor,
+        entry_price: torch.Tensor,
+        batch_indices: torch.Tensor,
+    ):
+        action = torch.where(time_idx >= 1, -position, torch.zeros_like(position))
+        return action, prev_stop
+
+
+@pytest.fixture
+def dummy_data_last_bar(base_instrument_config: BaseInstrumentConfig):
+    return DummyData(base_instrument_config, steps=1)
+
+
+@pytest.fixture
+def dummy_data_three_steps(base_instrument_config: BaseInstrumentConfig):
+    return DummyData(base_instrument_config, steps=3)
+
+
+def test_trading_policy_done_override(monkeypatch, dummy_data_last_bar):
+    monkeypatch.setattr(
+        DataManager,
+        "get_instrument_data",
+        lambda self, config, **_: dummy_data_last_bar,
+    )
+
+    policy = TradingPolicy(
+        instrument_data=dummy_data_last_bar,
+        open_position_policy=AlwaysOpenPolicy(1),
+        initial_stop_loss_policy=DummyInitialStopLoss(),
+        position_maintenance_policy=DummyMaintenance(),
+        trading_done_policy=AlwaysFalseDonePolicy(),
+    )
+
+    d_idx = torch.tensor([0], dtype=torch.int32)
+    t_idx = torch.tensor([0], dtype=torch.int32)
+    position = torch.tensor([0], dtype=torch.int32)
+    prev_stop = torch.tensor([float("nan")])
+    entry_price = torch.tensor([float("nan")])
+
+    _, _, done = policy(d_idx, t_idx, position, prev_stop, entry_price)
+    assert done.item() is True
+
+
+def test_single_market_env_rollout(monkeypatch, dummy_data_three_steps):
+    monkeypatch.setattr(
+        DataManager,
+        "get_instrument_data",
+        lambda self, config, **_: dummy_data_three_steps,
+    )
+
+    env = SingleMarketEnv(dummy_data_three_steps.instrument, "IBKR")
+    trading_policy = TradingPolicy(
+        instrument_data=env.instrument_data,
+        open_position_policy=AlwaysOpenPolicy(1),
+        initial_stop_loss_policy=DummyInitialStopLoss(),
+        position_maintenance_policy=CloseAfterOneStep(),
+        trading_done_policy=SingleTradeDonePolicy(),
+    )
+
+    start_d = torch.tensor([0], dtype=torch.int32)
+    start_t = torch.tensor([0], dtype=torch.int32)
+
+    result = env.rollout(trading_policy, start_d, start_t, max_steps=5)
+    assert env.done.item() is True
+    assert env.position.item() == 0
+    assert result.shape == (1,)


### PR DESCRIPTION
## Summary
- add `SingleMarketEnv` for running trading simulations
- extend `TradingPolicy` to accept a `trading_done_policy`
- implement `AlwaysFalseDonePolicy` and `SingleTradeDonePolicy`
- expose new classes in `__init__`
- test trading policy done override and environment rollout

## Testing
- `pylint ifera/environments.py ifera/policies.py ifera/__init__.py tests/test_single_market_env.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871334a3b688326b004dc122f3cd1ee