### PR TITLE
Define TradingDonePolicy interface

### DIFF
--- a/ifera/__init__.py
+++ b/ifera/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "ArtrStopLossPolicy",
     "InitialArtrStopLossPolicy",
     "ScaledArtrMaintenancePolicy",
+    "TradingDonePolicy",
     "AlwaysFalseDonePolicy",
     "SingleTradeDonePolicy",
     "SingleMarketEnv",


### PR DESCRIPTION
## Summary
- add `TradingDonePolicy` abstract class and use it in `TradingPolicy`
- expose `TradingDonePolicy` from top-level package
- test that `SingleMarketEnv.reset` invokes `reset` on done policy

## Testing
- `pylint ifera/policies.py ifera/__init__.py tests/test_single_market_env.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713c77b07483269524439769cc0b8d