### PR TITLE
Preallocate policy state tensors

### DIFF
--- a/tests/test_scaled_artr_policy.py
+++ b/tests/test_scaled_artr_policy.py
@@ -35,6 +35,7 @@ def test_scaled_artr_initialization(monkeypatch, dummy_instrument_data):
         atr_multiple=1.0,
         wait_for_breakeven=False,
         minimum_improvement=0.1,
+        batch_size=1,
     )
 
     assert policy.stage_count == 2
@@ -56,4 +57,5 @@ def test_scaled_artr_invalid_base(monkeypatch, dummy_instrument_data):
             atr_multiple=1.0,
             wait_for_breakeven=False,
             minimum_improvement=0.1,
+            batch_size=1,
         )

--- a/tests/test_single_market_env.py
+++ b/tests/test_single_market_env.py
@@ -121,7 +121,9 @@ def test_single_market_env_rollout(monkeypatch, dummy_data_three_steps):
         open_position_policy=AlwaysOpenPolicy(1),
         initial_stop_loss_policy=DummyInitialStopLoss(),
         position_maintenance_policy=CloseAfterOneStep(),
-        trading_done_policy=SingleTradeDonePolicy(),
+        trading_done_policy=SingleTradeDonePolicy(
+            batch_size=1, device=env.instrument_data.device
+        ),
     )
 
     start_d = torch.tensor([0], dtype=torch.int32)
@@ -144,7 +146,7 @@ def test_single_market_env_reset_calls_done_policy(monkeypatch, dummy_data_three
 
     class TrackingDonePolicy(SingleTradeDonePolicy):
         def __init__(self) -> None:
-            super().__init__()
+            super().__init__(batch_size=2, device=env.instrument_data.device)
             self.reset_called = False
             self.last_mask = None
 


### PR DESCRIPTION
## Summary
- pre-allocate state tensors in `ScaledArtrMaintenancePolicy`
- initialise state for `PercentGainMaintenancePolicy` and `SingleTradeDonePolicy`
- update tests for new constructor signatures

## Testing
- `pylint ifera/policies.py tests/test_scaled_artr_policy.py tests/test_single_market_env.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871449cf7108326899f9b6614f7e2e9