### PR TITLE
Refactor env state handling

### DIFF
--- a/tests/test_single_market_env.py
+++ b/tests/test_single_market_env.py
@@ -137,8 +137,8 @@ def test_single_market_env_rollout(monkeypatch, dummy_data_three_steps):
     start_t = torch.tensor([0], dtype=torch.int32)
 
     result = env.rollout(trading_policy, start_d, start_t, max_steps=5)
-    assert env.done.item() is True
-    assert env.position.item() == 0
+    assert env.state["done"].item() is True
+    assert env.state["position"].item() == 0
     assert result.shape == (1,)
 
 


### PR DESCRIPTION
## Summary
- manage environment tensors via a single state dict
- adapt step to take and return a state dict
- update rollout helpers and tests

## Testing
- `pylint ifera/environments.py tests/test_single_market_env.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879c6655fc48326a7156912b9713fb7