### PR TITLE
Add reset and masked_reset methods across policies

### DIFF
--- a/ifera/environments.py
+++ b/ifera/environments.py
@@ -131,9 +131,9 @@ class SingleMarketEnv:
         }
 
         if trading_policy is not None and hasattr(
-            trading_policy.trading_done_policy, "reset"
+            trading_policy.trading_done_policy, "masked_reset"
         ):
-            trading_policy.trading_done_policy.reset(
+            trading_policy.trading_done_policy.masked_reset(
                 torch.ones(batch_size, dtype=torch.bool, device=self.device)
             )
 
@@ -184,6 +184,7 @@ class SingleMarketEnv:
         """Execute a rollout until ``done`` for all batches or ``max_steps`` reached."""
 
         self.reset(start_date_idx, start_time_idx, trading_policy)
+        trading_policy.reset()
         steps = 0
         while True:
             torch.compiler.cudagraph_mark_step_begin()
@@ -216,6 +217,7 @@ class SingleMarketEnv:
         """Execute a rollout until ``done`` for all batches or ``max_steps`` reached."""
 
         self.reset(start_date_idx, start_time_idx, trading_policy)
+        trading_policy.reset()
         contract_multiplier = self.instrument_data.instrument.contract_multiplier
         steps = 0
         with Live(

--- a/ifera/policies/open_position_policy.py
+++ b/ifera/policies/open_position_policy.py
@@ -12,6 +12,11 @@ class OpenPositionPolicy(nn.Module, ABC):
     """Abstract base class for open position policies."""
 
     @abstractmethod
+    def reset(self) -> None:
+        """Reset any internal state held by the policy."""
+        raise NotImplementedError
+
+    @abstractmethod
     def forward(
         self,
         date_idx: torch.Tensor,
@@ -29,6 +34,11 @@ class AlwaysOpenPolicy(OpenPositionPolicy):
         super().__init__()
         _ = batch_size
         self.direction = torch.tensor(direction, dtype=torch.int32, device=device)
+        self.reset()
+
+    def reset(self) -> None:
+        """AlwaysOpenPolicy holds no state so nothing to reset."""
+        return None
 
     def forward(
         self,
@@ -47,6 +57,12 @@ class OpenOncePolicy(OpenPositionPolicy):
         super().__init__()
         self.direction = torch.tensor(direction, dtype=torch.int32, device=device)
         self.opened = torch.zeros((batch_size,), dtype=torch.bool, device=device)
+        self._zero = torch.zeros_like(self.opened)
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset ``opened`` state to ``False`` for all batches."""
+        self.opened = self._zero.clone()
 
     def forward(
         self,

--- a/ifera/policies/stop_loss_policy.py
+++ b/ifera/policies/stop_loss_policy.py
@@ -14,6 +14,11 @@ class StopLossPolicy(nn.Module, ABC):
     """Abstract base class for stop loss policies."""
 
     @abstractmethod
+    def reset(self) -> None:
+        """Reset policy state."""
+        raise NotImplementedError
+
+    @abstractmethod
     def forward(
         self,
         date_idx: torch.Tensor,
@@ -41,6 +46,11 @@ class ArtrStopLossPolicy(StopLossPolicy):
         self.atr_multiple = atr_multiple
         if len(instrument_data.artr) == 0:
             instrument_data.calculate_artr(alpha=alpha, acrossday=acrossday)
+        self.reset()
+
+    def reset(self) -> None:
+        """ArtrStopLossPolicy does not maintain state."""
+        return None
 
     def forward(
         self,
@@ -89,6 +99,11 @@ class InitialArtrStopLossPolicy(StopLossPolicy):
         device = instrument_data.device
         self._zero = torch.zeros(batch_size, dtype=torch.int32, device=device)
         self._nan = torch.full((batch_size,), float("nan"), dtype=dtype, device=device)
+        self.reset()
+
+    def reset(self) -> None:
+        """InitialArtrStopLossPolicy holds no state to reset."""
+        return None
 
     def forward(
         self,

--- a/ifera/policies/trading_policy.py
+++ b/ifera/policies/trading_policy.py
@@ -50,6 +50,18 @@ class TradingPolicy(BaseTradingPolicy):
         self.position_maintenance_policy = position_maintenance_policy
         self.trading_done_policy = trading_done_policy
         self._batch_size = batch_size
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset all sub-policies to their initial state."""
+        if hasattr(self.open_position_policy, "reset"):
+            self.open_position_policy.reset()
+        if hasattr(self.initial_stop_loss_policy, "reset"):
+            self.initial_stop_loss_policy.reset()
+        if hasattr(self.position_maintenance_policy, "reset"):
+            self.position_maintenance_policy.reset()
+        if hasattr(self.trading_done_policy, "reset"):
+            self.trading_done_policy.reset()
 
     def forward(
         self,
@@ -69,7 +81,7 @@ class TradingPolicy(BaseTradingPolicy):
         stop_loss = self.initial_stop_loss_policy(
             date_idx, time_idx, position, action, prev_stop
         )
-        self.position_maintenance_policy.reset(opening_position_mask)
+        self.position_maintenance_policy.masked_reset(opening_position_mask)
 
         maintenance_actions, maintenance_stops = self.position_maintenance_policy(
             date_idx, time_idx, position, prev_stop, entry_price

--- a/tests/test_single_market_env.py
+++ b/tests/test_single_market_env.py
@@ -42,8 +42,11 @@ class DummyInitialStopLoss(torch.nn.Module):
 
 
 class DummyMaintenance(PositionMaintenancePolicy):
-    def reset(self, mask: torch.Tensor) -> None:
+    def masked_reset(self, mask: torch.Tensor) -> None:
         pass
+
+    def reset(self) -> None:
+        return None
 
     def forward(
         self,
@@ -57,8 +60,11 @@ class DummyMaintenance(PositionMaintenancePolicy):
 
 
 class CloseAfterOneStep(PositionMaintenancePolicy):
-    def reset(self, mask: torch.Tensor) -> None:
+    def masked_reset(self, mask: torch.Tensor) -> None:
         pass
+
+    def reset(self) -> None:
+        return None
 
     def forward(
         self,
@@ -157,10 +163,12 @@ def test_single_market_env_reset_calls_done_policy(monkeypatch, dummy_data_three
             self.reset_called = False
             self.last_mask = torch.empty(0, dtype=torch.bool)
 
-        def reset(self, mask: torch.Tensor) -> None:  # pragma: no cover - simple flag
+        def masked_reset(
+            self, mask: torch.Tensor
+        ) -> None:  # pragma: no cover - simple flag
             self.reset_called = True
             self.last_mask = mask.clone()
-            super().reset(mask)
+            super().masked_reset(mask)
 
     done_policy = TrackingDonePolicy()
     trading_policy = TradingPolicy(


### PR DESCRIPTION
## Summary
- implement uniform `reset` semantics for policy classes
- add `masked_reset` for selective position resets
- cascade resets from `TradingPolicy`
- trigger policy resets in environment rollouts
- update tests for new method names

## Testing
- `pylint ifera/policies/open_position_policy.py ifera/policies/position_maintenance_policy.py ifera/policies/stop_loss_policy.py ifera/policies/trading_policy.py ifera/policies/trading_done_policy.py ifera/environments.py tests/test_single_market_env.py > /tmp/pylint.log && tail -n 20 /tmp/pylint.log`
- `bandit -c .bandit.yml -r ifera/policies/open_position_policy.py ifera/policies/position_maintenance_policy.py ifera/policies/stop_loss_policy.py ifera/policies/trading_done_policy.py ifera/policies/trading_policy.py ifera/environments.py tests/test_single_market_env.py > /tmp/bandit.log && tail -n 20 /tmp/bandit.log`
- `pytest -q > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_6879db11f0988326a4bc486b46609077