### PR TITLE
Enable multi-GPU rollout

### DIFF
--- a/ifera/__init__.py
+++ b/ifera/__init__.py
@@ -13,7 +13,7 @@ from .data_processing import (
 )
 from .file_manager import FileManager, RuleType
 from .market_simulator import MarketSimulatorIntraday
-from .environments import SingleMarketEnv
+from .environments import MultiGPUSingleMarketEnv, SingleMarketEnv
 from .masked_series import masked_artr, masked_ema, masked_rtr, masked_sma
 from .policies import *
 from .series import artr, ema, ema_slow, ffill, rtr, sma
@@ -60,6 +60,7 @@ __all__ = [
     "AlwaysFalseDonePolicy",
     "SingleTradeDonePolicy",
     "SingleMarketEnv",
+    "MultiGPUSingleMarketEnv",
     "FileManager",
     "Scheme",
     "Source",

--- a/tests/test_multi_gpu_env.py
+++ b/tests/test_multi_gpu_env.py
@@ -1,0 +1,57 @@
+import torch
+import pytest
+
+from ifera.data_models import DataManager
+from ifera.config import BaseInstrumentConfig
+from ifera.environments import MultiGPUSingleMarketEnv
+from ifera.policies import TradingPolicy, AlwaysOpenPolicy, SingleTradeDonePolicy
+
+from tests.test_single_market_env import (
+    DummyData,
+    DummyInitialStopLoss,
+    CloseAfterOneStep,
+)
+
+
+@pytest.fixture
+def dummy_data_three_steps_multi(base_instrument_config: BaseInstrumentConfig):
+    return DummyData(base_instrument_config, steps=3)
+
+
+def test_multi_gpu_env_rollout(monkeypatch, dummy_data_three_steps_multi):
+    monkeypatch.setattr(
+        DataManager,
+        "get_instrument_data",
+        lambda self, config, **_: dummy_data_three_steps_multi,
+    )
+
+    devices = [torch.device("cpu"), torch.device("cpu")]
+    env = MultiGPUSingleMarketEnv(
+        dummy_data_three_steps_multi.instrument, "IBKR", devices=devices
+    )
+
+    policies = []
+    for sub_env in env.envs:
+        policies.append(
+            TradingPolicy(
+                instrument_data=sub_env.instrument_data,
+                open_position_policy=AlwaysOpenPolicy(
+                    1, batch_size=1, device=sub_env.instrument_data.device
+                ),
+                initial_stop_loss_policy=DummyInitialStopLoss(),
+                position_maintenance_policy=CloseAfterOneStep(),
+                trading_done_policy=SingleTradeDonePolicy(
+                    batch_size=1, device=sub_env.instrument_data.device
+                ),
+                batch_size=1,
+            )
+        )
+
+    start_d = torch.tensor([0, 0], dtype=torch.int32)
+    start_t = torch.tensor([0, 0], dtype=torch.int32)
+
+    result = env.rollout(policies, start_d, start_t, max_steps=5)
+    assert result.shape == (2,)
+    for sub_env in env.envs:
+        assert sub_env.state["done"].all().item() is True
+        assert sub_env.state["position"].sum().item() == 0


### PR DESCRIPTION
## Summary
- support multi-GPU execution via `MultiGPUSingleMarketEnv`
- export the new environment
- update unit tests and add coverage for multi-GPU rollouts

## Testing
- `bandit -c .bandit.yml -r .`
- `pylint ifera/environments.py ifera/__init__.py tests/test_multi_gpu_env.py tests/test_single_market_env.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806640d8608326b5275aa83f50fdb1