### PR TITLE
Enable device transfer for policy modules

### DIFF
--- a/ifera/policies/open_position_policy.py
+++ b/ifera/policies/open_position_policy.py
@@ -35,7 +35,9 @@ class AlwaysOpenPolicy(OpenPositionPolicy):
     def __init__(self, direction: int, batch_size: int, device: torch.device) -> None:
         super().__init__()
         _ = batch_size
-        self.direction = torch.tensor(direction, dtype=torch.int32, device=device)
+        self.register_buffer(
+            "direction", torch.tensor(direction, dtype=torch.int32, device=device)
+        )
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """AlwaysOpenPolicy holds no state so nothing to reset."""
@@ -56,14 +58,15 @@ class OpenOncePolicy(OpenPositionPolicy):
 
     def __init__(self, direction: int, batch_size: int, device: torch.device) -> None:
         super().__init__()
-        self.direction = torch.tensor(direction, dtype=torch.int32, device=device)
+        self.register_buffer(
+            "direction", torch.tensor(direction, dtype=torch.int32, device=device)
+        )
         self._batch_size = batch_size
-        self.device = device
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """Reset ``opened`` state to ``False`` for all batches."""
         state["opened"] = torch.zeros(
-            self._batch_size, dtype=torch.bool, device=self.device
+            self._batch_size, dtype=torch.bool, device=self.direction.device
         )
 
     def forward(

--- a/ifera/policies/stop_loss_policy.py
+++ b/ifera/policies/stop_loss_policy.py
@@ -46,8 +46,8 @@ class ArtrStopLossPolicy(StopLossPolicy):
         self.atr_multiple = atr_multiple
         if len(instrument_data.artr) == 0:
             instrument_data.calculate_artr(alpha=alpha, acrossday=acrossday)
-        self._data = instrument_data.data
-        self._artr = instrument_data.artr
+        self.register_buffer("_data", instrument_data.data)
+        self.register_buffer("_artr", instrument_data.artr)
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """ArtrStopLossPolicy does not maintain state."""
@@ -98,15 +98,11 @@ class InitialArtrStopLossPolicy(StopLossPolicy):
     ) -> None:
         super().__init__()
         self.artr_policy = ArtrStopLossPolicy(instrument_data, atr_multiple)
-        dtype = instrument_data.data.dtype
-        device = instrument_data.device
-        self._zero = torch.zeros(batch_size, dtype=torch.int32, device=device)
-        self._nan = torch.full((batch_size,), float("nan"), dtype=dtype, device=device)
+        _ = batch_size
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """InitialArtrStopLossPolicy holds no state to reset."""
         _ = state
-        return None
 
     def forward(
         self,

--- a/ifera/policies/trading_done_policy.py
+++ b/ifera/policies/trading_done_policy.py
@@ -38,18 +38,18 @@ class AlwaysFalseDonePolicy(TradingDonePolicy):
 
     def __init__(self, batch_size: int, device: torch.device) -> None:
         super().__init__()
-        self._false = torch.zeros(batch_size, dtype=torch.bool, device=device)
+        self.register_buffer(
+            "_false", torch.zeros(batch_size, dtype=torch.bool, device=device)
+        )
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """No internal state to reset."""
         _ = state
-        return None
 
     def masked_reset(self, state: dict[str, torch.Tensor], mask: torch.Tensor) -> None:
         """No internal state to reset."""
         _ = state
         _ = mask
-        return None
 
     def forward(
         self,
@@ -64,8 +64,10 @@ class SingleTradeDonePolicy(TradingDonePolicy):
 
     def __init__(self, batch_size: int, device: torch.device) -> None:
         super().__init__()
-        self.had_position = torch.zeros(batch_size, dtype=torch.bool, device=device)
-        self._indices = torch.arange(batch_size, device=device)
+        self.register_buffer(
+            "had_position", torch.zeros(batch_size, dtype=torch.bool, device=device)
+        )
+        self.register_buffer("_indices", torch.arange(batch_size, device=device))
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """Reset ``had_position`` for all batches."""

--- a/tests/test_policies_to_device.py
+++ b/tests/test_policies_to_device.py
@@ -1,0 +1,125 @@
+"""Tests for moving policy modules between devices."""
+
+import torch
+import pytest
+
+from ifera.policies import (
+    AlwaysFalseDonePolicy,
+    AlwaysOpenPolicy,
+    ArtrStopLossPolicy,
+    InitialArtrStopLossPolicy,
+    OpenOncePolicy,
+    PercentGainMaintenancePolicy,
+    ScaledArtrMaintenancePolicy,
+    SingleTradeDonePolicy,
+    TradingPolicy,
+)
+from ifera.data_models import DataManager
+
+
+class DummyData:
+    """Minimal instrument data for policy tests."""
+
+    def __init__(self, instrument):
+        self.instrument = instrument
+        self.data = torch.zeros((2, 2, 4), dtype=torch.float32)
+        self.artr = torch.zeros((2, 2), dtype=torch.float32)
+        self.device = torch.device("cpu")
+        self.dtype = torch.float32
+        self.backadjust = False
+
+    def convert_indices(self, _base, date_idx, time_idx):
+        return date_idx, time_idx
+
+    def calculate_artr(self, alpha, acrossday):
+        _ = alpha
+        _ = acrossday
+        return None
+
+
+@pytest.fixture
+def dummy_instrument_data(base_instrument_config):
+    """Provide dummy instrument data based on the base config."""
+
+    return DummyData(base_instrument_config)
+
+
+@pytest.mark.parametrize(
+    "policy_fn",
+    [
+        lambda d: AlwaysOpenPolicy(1, batch_size=2, device=d.device),
+        lambda d: OpenOncePolicy(1, batch_size=2, device=d.device),
+        lambda d: ArtrStopLossPolicy(d, 1.0),
+        lambda d: InitialArtrStopLossPolicy(d, 1.0, batch_size=2),
+        lambda d: PercentGainMaintenancePolicy(
+            d,
+            stage1_atr_multiple=1.0,
+            trailing_stop=True,
+            skip_stage1=False,
+            keep_percent=0.5,
+            anchor_type="entry",
+            batch_size=2,
+        ),
+        lambda d: AlwaysFalseDonePolicy(batch_size=2, device=d.device),
+        lambda d: SingleTradeDonePolicy(batch_size=2, device=d.device),
+    ],
+)
+def test_policy_to_device(policy_fn, dummy_instrument_data):
+    """Policies should move buffers when ``to`` is called."""
+
+    policy = policy_fn(dummy_instrument_data)
+    target = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    policy.to(target)
+    assert all(buf.device == target for buf in policy.buffers())
+
+
+def test_scaled_artr_policy_to_device(monkeypatch, dummy_instrument_data):
+    """ScaledArtrMaintenancePolicy should move internal modules and buffers."""
+
+    def dummy_get(self, instrument_config, **_):
+        return DummyData(instrument_config)
+
+    monkeypatch.setattr(DataManager, "get_instrument_data", dummy_get)
+
+    policy = ScaledArtrMaintenancePolicy(
+        dummy_instrument_data,
+        [dummy_instrument_data.instrument.interval, "1h"],
+        atr_multiple=1.0,
+        wait_for_breakeven=False,
+        minimum_improvement=0.1,
+        batch_size=2,
+    )
+    target = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    policy.to(target)
+    assert all(buf.device == target for buf in policy.buffers())
+
+
+def test_trading_policy_to_device(dummy_instrument_data):
+    """Composite TradingPolicy should move all sub-policy buffers."""
+
+    batch_size = 2
+    open_policy = AlwaysOpenPolicy(
+        1, batch_size=batch_size, device=dummy_instrument_data.device
+    )
+    stop_policy = InitialArtrStopLossPolicy(dummy_instrument_data, 1.0, batch_size)
+    maint_policy = PercentGainMaintenancePolicy(
+        dummy_instrument_data,
+        stage1_atr_multiple=1.0,
+        trailing_stop=True,
+        skip_stage1=False,
+        keep_percent=0.5,
+        anchor_type="entry",
+        batch_size=batch_size,
+    )
+    done_policy = AlwaysFalseDonePolicy(batch_size, device=dummy_instrument_data.device)
+    policy = TradingPolicy(
+        dummy_instrument_data,
+        open_policy,
+        stop_policy,
+        maint_policy,
+        done_policy,
+        batch_size=batch_size,
+    )
+    target = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    policy.to(target)
+    assert all(buf.device == target for buf in policy.buffers())

--- a/tests/test_scaled_artr_policy.py
+++ b/tests/test_scaled_artr_policy.py
@@ -14,8 +14,8 @@ class DummyData:
         self.dtype = torch.float32
         self.backadjust = False
 
-    def convert_indices(self, *_args):
-        return _args
+    def convert_indices(self, _base, date_idx, time_idx):
+        return date_idx, time_idx
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- register constant tensors as buffers across policy modules to support `.to()` device movement
- switch ScaledArtrMaintenancePolicy to use `ModuleList` for ATR policies and converted indices
- add comprehensive tests ensuring policy tensors move to requested devices

## Testing
- `pylint ifera/policies/open_position_policy.py ifera/policies/stop_loss_policy.py ifera/policies/position_maintenance_policy.py ifera/policies/trading_done_policy.py tests/test_policies_to_device.py tests/test_single_market_env.py tests/test_scaled_artr_policy.py`
- `bandit -c .bandit.yml -r .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f200130fc832680eb93f4a9844a78