### PR TITLE
Enable moving policies between devices

### DIFF
--- a/ifera/policies/open_position_policy.py
+++ b/ifera/policies/open_position_policy.py
@@ -35,7 +35,9 @@ class AlwaysOpenPolicy(OpenPositionPolicy):
     def __init__(self, direction: int, batch_size: int, device: torch.device) -> None:
         super().__init__()
         _ = batch_size
-        self.direction = torch.tensor(direction, dtype=torch.int32, device=device)
+        self.register_buffer(
+            "direction", torch.tensor(direction, dtype=torch.int32, device=device)
+        )
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """AlwaysOpenPolicy holds no state so nothing to reset."""
@@ -56,14 +58,15 @@ class OpenOncePolicy(OpenPositionPolicy):
 
     def __init__(self, direction: int, batch_size: int, device: torch.device) -> None:
         super().__init__()
-        self.direction = torch.tensor(direction, dtype=torch.int32, device=device)
+        self.register_buffer(
+            "direction", torch.tensor(direction, dtype=torch.int32, device=device)
+        )
         self._batch_size = batch_size
-        self.device = device
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """Reset ``opened`` state to ``False`` for all batches."""
         state["opened"] = torch.zeros(
-            self._batch_size, dtype=torch.bool, device=self.device
+            self._batch_size, dtype=torch.bool, device=self.direction.device
         )
 
     def forward(

--- a/ifera/policies/position_maintenance_policy.py
+++ b/ifera/policies/position_maintenance_policy.py
@@ -15,6 +15,17 @@ from ..file_manager import FileManager
 from .stop_loss_policy import ArtrStopLossPolicy
 
 
+class _IndexConversion(nn.Module):
+    def __init__(self, date_idx: torch.Tensor, time_idx: torch.Tensor) -> None:
+        super().__init__()
+        self.register_buffer("date_idx", date_idx)
+        self.register_buffer("time_idx", time_idx)
+
+    def forward(self) -> None:  # pragma: no cover
+        """_IndexConversion is a holder module and should not be called."""
+        raise NotImplementedError
+
+
 class PositionMaintenancePolicy(nn.Module, ABC):
     """Abstract base class for position maintenance policies."""
 
@@ -95,24 +106,36 @@ class ScaledArtrMaintenancePolicy(PositionMaintenancePolicy):
         date_idx = repeat(date_idx_base, "d -> d t", t=time_idx_base.size(0))
         time_idx = repeat(time_idx_base, "t -> d t", d=date_idx_base.size(0))
 
-        self.converted_indices = [
+        converted = [
             self.derived_data[s].convert_indices(
                 self.derived_data[0], date_idx, time_idx
             )
             for s in range(len(self.derived_data))
         ]
 
-        self.artr_policies = [
+        self.converted_indices = nn.ModuleList(
+            _IndexConversion(d_idx, t_idx) for d_idx, t_idx in converted
+        )
+
+        self.artr_policies = nn.ModuleList(
             ArtrStopLossPolicy(data, self.atr_multiple) for data in self.derived_data
-        ]
+        )
         self.stage_count = len(stages)
 
         device = instrument_data.device
         dtype = instrument_data.dtype
-        self._action = torch.zeros(batch_size, dtype=torch.int32, device=device)
-        self._stop = torch.empty(batch_size, dtype=dtype, device=device)
-        self._zero = torch.zeros(self.batch_size, dtype=torch.int32, device=device)
-        self._nan = torch.full((batch_size,), float("nan"), dtype=dtype, device=device)
+        self.register_buffer(
+            "_action", torch.zeros(batch_size, dtype=torch.int32, device=device)
+        )
+        self.register_buffer(
+            "_stop", torch.empty(batch_size, dtype=dtype, device=device)
+        )
+        self.register_buffer(
+            "_zero", torch.zeros(self.batch_size, dtype=torch.int32, device=device)
+        )
+        self.register_buffer(
+            "_nan", torch.full((batch_size,), float("nan"), dtype=dtype, device=device)
+        )
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """Fully reset internal stage and base price."""
@@ -162,8 +185,8 @@ class ScaledArtrMaintenancePolicy(PositionMaintenancePolicy):
 
         for s in range(1, self.stage_count):
             stage_mask = stage == s
-            conv_date_idx = self.converted_indices[s][0][date_idx, time_idx]
-            conv_time_idx = self.converted_indices[s][1][date_idx, time_idx]
+            conv_date_idx = self.converted_indices[s].date_idx[date_idx, time_idx]
+            conv_time_idx = self.converted_indices[s].time_idx[date_idx, time_idx]
             conv_state = {
                 "date_idx": conv_date_idx,
                 "time_idx": conv_time_idx,
@@ -233,7 +256,7 @@ class PercentGainMaintenancePolicy(PositionMaintenancePolicy):
             )
 
         self.instrument_data = instrument_data
-        self._data = instrument_data.data
+        self.register_buffer("_data", instrument_data.data)
         self.trailing_stop = trailing_stop
         self.skip_stage1 = skip_stage1
         self.keep_percent = keep_percent
@@ -243,12 +266,19 @@ class PercentGainMaintenancePolicy(PositionMaintenancePolicy):
         device = instrument_data.device
         dtype = instrument_data.dtype
         initial_stage = 1 if self.skip_stage1 else 0
-        self._action = torch.zeros(batch_size, dtype=torch.int32, device=device)
-        self._stop = torch.empty(batch_size, dtype=dtype, device=device)
-        self._initial_stage = torch.full(
-            (batch_size,), initial_stage, dtype=torch.long, device=device
+        self.register_buffer(
+            "_action", torch.zeros(batch_size, dtype=torch.int32, device=device)
         )
-        self._nan = torch.full((batch_size,), float("nan"), dtype=dtype, device=device)
+        self.register_buffer(
+            "_stop", torch.empty(batch_size, dtype=dtype, device=device)
+        )
+        self.register_buffer(
+            "_initial_stage",
+            torch.full((batch_size,), initial_stage, dtype=torch.long, device=device),
+        )
+        self.register_buffer(
+            "_nan", torch.full((batch_size,), float("nan"), dtype=dtype, device=device)
+        )
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """Fully reset stage and anchor state."""

--- a/ifera/policies/stop_loss_policy.py
+++ b/ifera/policies/stop_loss_policy.py
@@ -46,8 +46,8 @@ class ArtrStopLossPolicy(StopLossPolicy):
         self.atr_multiple = atr_multiple
         if len(instrument_data.artr) == 0:
             instrument_data.calculate_artr(alpha=alpha, acrossday=acrossday)
-        self._data = instrument_data.data
-        self._artr = instrument_data.artr
+        self.register_buffer("_data", instrument_data.data)
+        self.register_buffer("_artr", instrument_data.artr)
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """ArtrStopLossPolicy does not maintain state."""
@@ -100,13 +100,16 @@ class InitialArtrStopLossPolicy(StopLossPolicy):
         self.artr_policy = ArtrStopLossPolicy(instrument_data, atr_multiple)
         dtype = instrument_data.data.dtype
         device = instrument_data.device
-        self._zero = torch.zeros(batch_size, dtype=torch.int32, device=device)
-        self._nan = torch.full((batch_size,), float("nan"), dtype=dtype, device=device)
+        self.register_buffer(
+            "_zero", torch.zeros(batch_size, dtype=torch.int32, device=device)
+        )
+        self.register_buffer(
+            "_nan", torch.full((batch_size,), float("nan"), dtype=dtype, device=device)
+        )
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """InitialArtrStopLossPolicy holds no state to reset."""
         _ = state
-        return None
 
     def forward(
         self,

--- a/ifera/policies/trading_done_policy.py
+++ b/ifera/policies/trading_done_policy.py
@@ -38,18 +38,18 @@ class AlwaysFalseDonePolicy(TradingDonePolicy):
 
     def __init__(self, batch_size: int, device: torch.device) -> None:
         super().__init__()
-        self._false = torch.zeros(batch_size, dtype=torch.bool, device=device)
+        self.register_buffer(
+            "_false", torch.zeros(batch_size, dtype=torch.bool, device=device)
+        )
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """No internal state to reset."""
         _ = state
-        return None
 
     def masked_reset(self, state: dict[str, torch.Tensor], mask: torch.Tensor) -> None:
         """No internal state to reset."""
         _ = state
         _ = mask
-        return None
 
     def forward(
         self,
@@ -64,8 +64,10 @@ class SingleTradeDonePolicy(TradingDonePolicy):
 
     def __init__(self, batch_size: int, device: torch.device) -> None:
         super().__init__()
-        self.had_position = torch.zeros(batch_size, dtype=torch.bool, device=device)
-        self._indices = torch.arange(batch_size, device=device)
+        self.register_buffer(
+            "had_position", torch.zeros(batch_size, dtype=torch.bool, device=device)
+        )
+        self.register_buffer("_indices", torch.arange(batch_size, device=device))
 
     def reset(self, state: dict[str, torch.Tensor]) -> None:
         """Reset ``had_position`` for all batches."""

--- a/tests/test_policy_device.py
+++ b/tests/test_policy_device.py
@@ -1,0 +1,115 @@
+import torch
+import pytest
+
+from ifera.policies import (
+    AlwaysOpenPolicy,
+    OpenOncePolicy,
+    ArtrStopLossPolicy,
+    InitialArtrStopLossPolicy,
+    PercentGainMaintenancePolicy,
+    ScaledArtrMaintenancePolicy,
+    AlwaysFalseDonePolicy,
+    SingleTradeDonePolicy,
+    TradingPolicy,
+)
+from ifera.data_models import DataManager
+
+
+class DummyData:
+    def __init__(self, instrument):
+        self.instrument = instrument
+        self.data = torch.zeros((2, 2, 4), dtype=torch.float32)
+        self.artr = torch.ones((2, 2), dtype=torch.float32)
+        self.device = torch.device("cpu")
+        self.dtype = torch.float32
+        self.backadjust = False
+
+    def convert_indices(self, _base, date_idx, time_idx):
+        return date_idx, time_idx
+
+
+def _target_device() -> torch.device:
+    return torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+
+
+@pytest.fixture
+def dummy_instrument_data(base_instrument_config):
+    return DummyData(base_instrument_config)
+
+
+def test_simple_policies_to_device(dummy_instrument_data):
+    device = _target_device()
+    policies = [
+        AlwaysOpenPolicy(direction=1, batch_size=1, device=torch.device("cpu")),
+        OpenOncePolicy(direction=1, batch_size=1, device=torch.device("cpu")),
+        ArtrStopLossPolicy(dummy_instrument_data, atr_multiple=1.0),
+        InitialArtrStopLossPolicy(
+            dummy_instrument_data, atr_multiple=1.0, batch_size=1
+        ),
+        PercentGainMaintenancePolicy(
+            dummy_instrument_data,
+            stage1_atr_multiple=1.0,
+            trailing_stop=True,
+            skip_stage1=False,
+            keep_percent=0.5,
+            anchor_type="entry",
+            batch_size=1,
+        ),
+        AlwaysFalseDonePolicy(batch_size=1, device=torch.device("cpu")),
+        SingleTradeDonePolicy(batch_size=1, device=torch.device("cpu")),
+    ]
+    for policy in policies:
+        policy.to(device)
+        for tensor in policy.state_dict().values():
+            assert tensor.device == device
+
+
+def test_scaled_artr_policy_to_device(monkeypatch, dummy_instrument_data):
+    def dummy_get(self, instrument_config, **_):
+        return DummyData(instrument_config)
+
+    monkeypatch.setattr(DataManager, "get_instrument_data", dummy_get)
+
+    policy = ScaledArtrMaintenancePolicy(
+        dummy_instrument_data,
+        [dummy_instrument_data.instrument.interval, "1h"],
+        atr_multiple=1.0,
+        wait_for_breakeven=False,
+        minimum_improvement=0.1,
+        batch_size=1,
+    )
+    device = _target_device()
+    policy.to(device)
+    for tensor in policy.state_dict().values():
+        assert tensor.device == device
+
+
+def test_trading_policy_to_device(dummy_instrument_data):
+    device = _target_device()
+    open_policy = AlwaysOpenPolicy(
+        direction=1, batch_size=1, device=torch.device("cpu")
+    )
+    initial_stop = InitialArtrStopLossPolicy(
+        dummy_instrument_data, atr_multiple=1.0, batch_size=1
+    )
+    maintenance = PercentGainMaintenancePolicy(
+        dummy_instrument_data,
+        stage1_atr_multiple=1.0,
+        trailing_stop=True,
+        skip_stage1=False,
+        keep_percent=0.5,
+        anchor_type="entry",
+        batch_size=1,
+    )
+    done_policy = AlwaysFalseDonePolicy(batch_size=1, device=torch.device("cpu"))
+    trading_policy = TradingPolicy(
+        dummy_instrument_data,
+        open_policy,
+        initial_stop,
+        maintenance,
+        done_policy,
+        batch_size=1,
+    )
+    trading_policy.to(device)
+    for tensor in trading_policy.state_dict().values():
+        assert tensor.device == device

--- a/tests/test_scaled_artr_policy.py
+++ b/tests/test_scaled_artr_policy.py
@@ -14,8 +14,8 @@ class DummyData:
         self.dtype = torch.float32
         self.backadjust = False
 
-    def convert_indices(self, *_args):
-        return _args
+    def convert_indices(self, _base, date_idx, time_idx):
+        return date_idx, time_idx
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- register policy tensors as buffers and convert lists of sub-policies to `ModuleList`
- add tests ensuring `.to(device)` moves policy tensors

## Testing
- `pylint ifera/policies/open_position_policy.py ifera/policies/stop_loss_policy.py ifera/policies/trading_done_policy.py ifera/policies/position_maintenance_policy.py tests/test_policy_device.py`
- `bandit -c .bandit.yml -r .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ceb3cba48326a03ef05a8cd16e1a