### PR TITLE
Add helper to clone trading policies across devices

### DIFF
--- a/ifera/environments.py
+++ b/ifera/environments.py
@@ -13,6 +13,7 @@ from .config import BaseInstrumentConfig
 from .data_models import DataManager, InstrumentData
 from .market_simulator import MarketSimulatorIntraday
 from .policies import TradingPolicy
+from .torch_utils import get_devices
 
 
 def make_table(
@@ -279,12 +280,7 @@ class MultiGPUSingleMarketEnv:
         devices: Optional[list[torch.device]] = None,
         dtype: torch.dtype = torch.float32,
     ) -> None:
-        if devices is None:
-            device_count = torch.cuda.device_count()
-            if device_count == 0:
-                devices = [torch.device("cpu")]
-            else:
-                devices = [torch.device(f"cuda:{idx}") for idx in range(device_count)]
+        devices = get_devices(devices)
 
         self.envs = [
             SingleMarketEnv(

--- a/ifera/policies/__init__.py
+++ b/ifera/policies/__init__.py
@@ -1,6 +1,10 @@
 """Convenience exports for policy classes."""
 
-from .trading_policy import BaseTradingPolicy, TradingPolicy
+from .trading_policy import (
+    BaseTradingPolicy,
+    TradingPolicy,
+    clone_trading_policy_for_devices,
+)
 from .open_position_policy import OpenPositionPolicy, AlwaysOpenPolicy, OpenOncePolicy
 from .stop_loss_policy import (
     StopLossPolicy,
@@ -33,4 +37,5 @@ __all__ = [
     "TradingDonePolicy",
     "AlwaysFalseDonePolicy",
     "SingleTradeDonePolicy",
+    "clone_trading_policy_for_devices",
 ]

--- a/ifera/torch_utils.py
+++ b/ifera/torch_utils.py
@@ -1,0 +1,32 @@
+"""Utility helpers for working with PyTorch devices."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import nn
+
+
+def get_devices(devices: Optional[list[torch.device]] = None) -> list[torch.device]:
+    """Return a list of devices using CUDA devices by default.
+
+    If ``devices`` is ``None``, all available CUDA devices are returned. When
+    no CUDA devices are available a single CPU device is used instead.
+    """
+    if devices is not None:
+        return devices
+
+    device_count = torch.cuda.device_count()
+    if device_count == 0:
+        return [torch.device("cpu")]
+    return [torch.device(f"cuda:{idx}") for idx in range(device_count)]
+
+
+def get_module_device(module: nn.Module) -> torch.device:
+    """Return the device on which ``module`` is allocated."""
+    for param in module.parameters():
+        return param.device
+    for buf in module.buffers():
+        return buf.device
+    return torch.device("cpu")

--- a/tests/test_multi_gpu_env.py
+++ b/tests/test_multi_gpu_env.py
@@ -4,7 +4,12 @@ import pytest
 from ifera.data_models import DataManager
 from ifera.config import BaseInstrumentConfig
 from ifera.environments import MultiGPUSingleMarketEnv
-from ifera.policies import TradingPolicy, AlwaysOpenPolicy, SingleTradeDonePolicy
+from ifera.policies import (
+    TradingPolicy,
+    AlwaysOpenPolicy,
+    SingleTradeDonePolicy,
+    clone_trading_policy_for_devices,
+)
 
 from tests.test_single_market_env import (
     DummyData,
@@ -30,22 +35,20 @@ def test_multi_gpu_env_rollout(monkeypatch, dummy_data_three_steps_multi):
         dummy_data_three_steps_multi.instrument, "IBKR", devices=devices
     )
 
-    policies = []
-    for sub_env in env.envs:
-        policies.append(
-            TradingPolicy(
-                instrument_data=sub_env.instrument_data,
-                open_position_policy=AlwaysOpenPolicy(
-                    1, batch_size=1, device=sub_env.instrument_data.device
-                ),
-                initial_stop_loss_policy=DummyInitialStopLoss(),
-                position_maintenance_policy=CloseAfterOneStep(),
-                trading_done_policy=SingleTradeDonePolicy(
-                    batch_size=1, device=sub_env.instrument_data.device
-                ),
-                batch_size=1,
-            )
-        )
+    base_env = env.envs[0]
+    base_policy = TradingPolicy(
+        instrument_data=base_env.instrument_data,
+        open_position_policy=AlwaysOpenPolicy(
+            1, batch_size=1, device=base_env.instrument_data.device
+        ),
+        initial_stop_loss_policy=DummyInitialStopLoss(),
+        position_maintenance_policy=CloseAfterOneStep(),
+        trading_done_policy=SingleTradeDonePolicy(
+            batch_size=1, device=base_env.instrument_data.device
+        ),
+        batch_size=1,
+    )
+    policies = clone_trading_policy_for_devices(base_policy, env.devices)
 
     start_d = torch.tensor([0, 0], dtype=torch.int32)
     start_t = torch.tensor([0, 0], dtype=torch.int32)

--- a/tests/test_trading_policy_clone.py
+++ b/tests/test_trading_policy_clone.py
@@ -1,0 +1,39 @@
+import torch
+
+from ifera.policies import (
+    TradingPolicy,
+    AlwaysOpenPolicy,
+    SingleTradeDonePolicy,
+    clone_trading_policy_for_devices,
+)
+from tests.test_single_market_env import (
+    DummyData,
+    DummyInitialStopLoss,
+    CloseAfterOneStep,
+)
+from ifera.config import BaseInstrumentConfig
+
+
+def test_clone_trading_policy_for_devices(base_instrument_config: BaseInstrumentConfig):
+    dummy_data = DummyData(base_instrument_config, steps=3)
+    base_policy = TradingPolicy(
+        instrument_data=dummy_data,
+        open_position_policy=AlwaysOpenPolicy(
+            1, batch_size=1, device=dummy_data.device
+        ),
+        initial_stop_loss_policy=DummyInitialStopLoss(),
+        position_maintenance_policy=CloseAfterOneStep(),
+        trading_done_policy=SingleTradeDonePolicy(
+            batch_size=1, device=dummy_data.device
+        ),
+        batch_size=1,
+    )
+
+    devices = [torch.device("cpu"), torch.device("cpu")]
+    policies = clone_trading_policy_for_devices(base_policy, devices)
+
+    assert len(policies) == 2
+    assert policies[0] is base_policy
+    assert policies[1] is not base_policy
+    for policy in policies:
+        assert next(policy.buffers()).device == torch.device("cpu")


### PR DESCRIPTION
## Summary
- share device selection logic via new `get_devices` helper
- add `clone_trading_policy_for_devices` to replicate a policy across devices
- refactor `MultiGPUSingleMarketEnv` to use shared device helper

## Testing
- `pylint ifera/torch_utils.py`
- `pylint ifera/environments.py`
- `pylint ifera/policies/trading_policy.py`
- `pylint ifera/policies/__init__.py`
- `bandit -c .bandit.yml -r .`
- `pytest tests/test_trading_policy_clone.py tests/test_multi_gpu_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f828cd2c8326a782b07a00cb2ad2