### PR TITLE
Avoid Python bool for position maintenance predicate

### DIFF
--- a/ifera/policies/position_maintenance_policy.py
+++ b/ifera/policies/position_maintenance_policy.py
@@ -228,7 +228,7 @@ class ScaledArtrMaintenancePolicy(PositionMaintenancePolicy):
         def false_branch(stage_tensor, stop_tensor, _):
             return 0, stage_tensor, stop_tensor
 
-        predicate = bool(torch.any(nonzero_mask))
+        predicate = torch.any(nonzero_mask)
         _, stage, stop_loss = torch.cond(
             predicate,
             true_branch,

--- a/tests/test_position_maintenance_predicate_tensor.py
+++ b/tests/test_position_maintenance_predicate_tensor.py
@@ -1,0 +1,58 @@
+import torch
+import pytest
+
+from ifera.policies import ScaledArtrMaintenancePolicy
+from ifera.data_models import DataManager
+
+
+class DummyData:
+    def __init__(self, instrument):
+        self.instrument = instrument
+        self.data = torch.zeros((1, 1, 4), dtype=torch.float32)
+        self.artr = torch.zeros((1, 1), dtype=torch.float32)
+        self.device = torch.device("cpu")
+        self.dtype = torch.float32
+        self.backadjust = False
+
+    def convert_indices(self, _base, date_idx, time_idx):
+        return date_idx, time_idx
+
+
+@pytest.fixture
+def dummy_instrument_data(base_instrument_config):
+    return DummyData(base_instrument_config)
+
+
+def test_scaled_artr_cond_predicate_is_tensor(monkeypatch, dummy_instrument_data):
+    def dummy_get(self, instrument_config, **_):
+        return DummyData(instrument_config)
+
+    monkeypatch.setattr(DataManager, "get_instrument_data", dummy_get)
+
+    policy = ScaledArtrMaintenancePolicy(
+        dummy_instrument_data,
+        [dummy_instrument_data.instrument.interval, "1h"],
+        atr_multiple=1.0,
+        wait_for_breakeven=False,
+        minimum_improvement=0.1,
+        batch_size=1,
+    )
+
+    def fake_cond(pred, true_fn, false_fn, operands):
+        assert isinstance(pred, torch.Tensor)
+        assert pred.dtype == torch.bool
+        return false_fn(*operands)
+
+    monkeypatch.setattr(torch, "cond", fake_cond)
+
+    state = {
+        "date_idx": torch.tensor([0]),
+        "time_idx": torch.tensor([0]),
+        "entry_price": torch.tensor([1.0]),
+        "prev_stop_loss": torch.tensor([0.5]),
+        "position": torch.tensor([1]),
+        "base_price": torch.tensor([1.0]),
+        "maint_stage": torch.tensor([0]),
+    }
+
+    policy(state)


### PR DESCRIPTION
## Summary
- use `torch.any` tensor directly as predicate for `torch.cond` in position maintenance
- add regression test ensuring the predicate is a boolean tensor

## Testing
- `pylint ifera/policies/position_maintenance_policy.py`
- `bandit -c .bandit.yml -r .`
- `pytest tests/test_position_maintenance_predicate_tensor.py`


------
https://chatgpt.com/codex/tasks/task_e_689c50bab1408326b321442df0680f01