### PR TITLE
Enable scalar capture for higher-order ops

### DIFF
--- a/ifera/policies/position_maintenance_policy.py
+++ b/ifera/policies/position_maintenance_policy.py
@@ -6,13 +6,15 @@ from abc import ABC, abstractmethod
 from typing import List, Tuple
 
 import torch
+import torch._dynamo  # pylint: disable=protected-access
 from torch import nn
 from einops import repeat
-
 from ..data_models import InstrumentData, DataManager
 from ..config import ConfigManager
 from ..file_manager import FileManager
 from .stop_loss_policy import ArtrStopLossPolicy
+
+torch._dynamo.config.capture_scalar_outputs = True  # pylint: disable=protected-access
 
 
 class PositionMaintenancePolicy(nn.Module, ABC):

--- a/tests/test_capture_scalar_outputs.py
+++ b/tests/test_capture_scalar_outputs.py
@@ -1,0 +1,7 @@
+import torch
+
+import ifera.policies.position_maintenance_policy  # noqa: F401
+
+
+def test_capture_scalar_outputs_enabled():
+    assert torch._dynamo.config.capture_scalar_outputs is True


### PR DESCRIPTION
## Summary
- ensure torch.compile can capture data-dependent scalars in position maintenance policy
- add test confirming capture_scalar_outputs is enabled

## Testing
- `pylint ifera/policies/position_maintenance_policy.py`
- `bandit -c .bandit.yml -r .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c7f7fceb08326a6ca8a692e119820