### PR TITLE
Remove unused GraphPlan mappings and filter noop actions

### DIFF
--- a/tests/test_graphplan.py
+++ b/tests/test_graphplan.py
@@ -12,5 +12,7 @@ def test_graphplan_sample():
     plan = planner.run()
     assert plan is not None
     flattened = [act for layer in plan for act in layer]
+    noop_names = {a["name"] for a in planner.all_actions if a.get("noop")}
+    assert all(act not in noop_names for act in flattened)
     for action in ["paint_green", "increment_to_1", "set_to_3", "make_safe"]:
         assert action in flattened


### PR DESCRIPTION
## Summary
- remove unused proposition mapping variables in GraphPlan preprocessing
- skip noop actions when extracting final plan via explicit `noop` flag
- test ensures GraphPlan output excludes flagged noop actions

## Testing
- `python -m black algorithms/graphplan.py tests/test_graphplan.py`
- `pylint algorithms/graphplan.py`
- `bandit -c .bandit.yml -r .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0cb2ea2f08326b8f235cda10d9ce8