### PR TITLE
fix: enable cross-level backtracking in GraphPlan

### DIFF
--- a/tests/test_graphplan.py
+++ b/tests/test_graphplan.py
@@ -16,3 +16,13 @@ def test_graphplan_sample():
     assert all(act not in noop_names for act in flattened)
     for action in ["paint_green", "increment_to_1", "set_to_3", "make_safe"]:
         assert action in flattened
+
+
+def test_graphplan_backtrack():
+    """GraphPlan should backtrack across levels to find valid plan."""
+    yaml_path = Path(__file__).with_name("test_graphplan_backtrack.yml")
+    planner = GraphPlan(str(yaml_path))
+    plan = planner.run()
+    assert plan is not None
+    flattened = sorted(act for layer in plan for act in layer)
+    assert flattened == ["a2", "b2"]

--- a/tests/test_graphplan_backtrack.yml
+++ b/tests/test_graphplan_backtrack.yml
@@ -1,0 +1,36 @@
+propositions:
+  - A
+  - B
+  - p
+  - q
+actions:
+  - name: a1
+    preconds:
+      - q
+    add:
+      - A
+    del:
+      - p
+  - name: a2
+    preconds:
+      - q
+    add:
+      - A
+  - name: b1
+    preconds:
+      - p
+    add:
+      - B
+    del:
+      - q
+  - name: b2
+    preconds:
+      - p
+    add:
+      - B
+initial:
+  - p
+  - q
+goals:
+  - A
+  - B


### PR DESCRIPTION
## Summary
- avoid pruning viable subgoal sets by tracking selected actions in failure cache
- allow `_extract_plan` to backtrack across levels when deeper layers fail
- add regression test for mutex/backtracking scenario

## Testing
- `pylint algorithms/graphplan.py`
- `bandit -c .bandit.yml -r .`
- `pytest tests/test_graphplan.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0dbfc42d08326b8ba160bbbf2d14d