### PR TITLE
feat: expand disjunctive action preconditions

### DIFF
--- a/tests/test_graphplan.py
+++ b/tests/test_graphplan.py
@@ -26,3 +26,15 @@ def test_graphplan_backtrack():
     assert plan is not None
     flattened = sorted(act for layer in plan for act in layer)
     assert flattened == ["a2", "b2"]
+
+
+def test_graphplan_disjunctive_preconditions():
+    """Actions with OR preconditions should expand into multiple variants."""
+    yaml_path = Path(__file__).with_name("test_graphplan_disjunction.yml")
+    planner = GraphPlan(str(yaml_path))
+    action_names = {a["name"] for a in planner.all_actions}
+    assert {f"achieve_goal_v{i}" for i in range(4)} <= action_names
+    plan = planner.run()
+    assert plan is not None
+    flattened = [act for layer in plan for act in layer]
+    assert any(act.startswith("achieve_goal") for act in flattened)

--- a/tests/test_graphplan_disjunction.yml
+++ b/tests/test_graphplan_disjunction.yml
@@ -1,0 +1,20 @@
+propositions:
+  - p1
+  - p2
+  - q1
+  - q2
+  - goal
+actions:
+  - name: achieve_goal
+    preconds:
+      - [p1, p2]
+      - [q1, q2]
+    add:
+      - goal
+initial:
+  - p1
+  - p2
+  - q1
+  - q2
+goals:
+  - goal


### PR DESCRIPTION
## Summary
- allow YAML actions to use OR groups in preconditions and expand them into variants
- add test case and sample YAML demonstrating disjunctive preconditions

## Testing
- `pylint algorithms/graphplan.py`
- `bandit -c .bandit.yml -r .`
- `pytest tests/test_graphplan.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0f43077748326bee51c6056b6b5af