### PR TITLE
Rename Copilot setup workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup-environment:
+  copilot-setup-steps:
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
## Summary
- rename `copilot-agent-setup.yml` to `copilot-setup-steps.yml`
- rename workflow job to `copilot-setup-steps`

## Testing
- `pylint $(git ls-files '*.py')`
- `pyright ifera` (fails: Type "Series" is not assignable to "DataFrame")
- `bandit -r .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1c7e48c9c83268d926c70c4f0b6a8